### PR TITLE
Separate unit and integration test workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,29 +1,34 @@
 name: Deploy to Server
 
 on:
-  workflow_run:
-    workflows: ["CI Unit Tests"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
+      - staging
+      - prod
+  workflow_dispatch:
 
 jobs:
+  run-unit-tests:
+    uses: ./.github/workflows/unit-tests.yml
+
+  run-integration-tests:
+    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod'
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
+
   deploy:
     name: Deploy application
+    needs: run-unit-tests
     runs-on: ubuntu-latest
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      (
-        github.event.workflow_run.head_branch == 'main' ||
-        github.event.workflow_run.head_branch == 'staging' ||
-        github.event.workflow_run.head_branch == 'prod'
-      )
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/staging' ||
+      github.ref == 'refs/heads/prod'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.8.0
@@ -33,7 +38,7 @@ jobs:
       - name: Determine deployment target
         id: env
         env:
-          TARGET_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          TARGET_BRANCH: ${{ github.ref_name }}
         run: |
           BRANCH="$TARGET_BRANCH"
           case "$BRANCH" in

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Server
 
 on:
   workflow_run:
-    workflows: ["CI Tests"]
+    workflows: ["CI Unit Tests"]
     types:
       - completed
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,82 @@
+name: CI Integration Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+  push:
+    branches:
+      - staging
+
+jobs:
+  integration-tests:
+    name: Run integration tests against dev
+    runs-on: ubuntu-latest
+
+    env:
+      CONFLAGENT_DEV_URL: ${{ secrets.CONFLAGENT_DEV_URL }}
+      CONFLAGENT_DEV_ENDPOINT: ${{ secrets.CONFLAGENT_DEV_ENDPOINT }}
+      CONFLAGENT_DEV_TOKEN: ${{ secrets.CONFLAGENT_DEV_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure GitHub CLI is installed
+        run: |
+          if ! command -v gh >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y gh
+          fi
+
+      - name: Check for commits since last completed run
+        if: github.event_name == 'schedule'
+        id: commit-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_SHA=$(git rev-parse HEAD)
+          LAST_COMPLETED_SHA=$(gh run list \
+            --workflow "$GITHUB_WORKFLOW" \
+            --branch "$GITHUB_REF_NAME" \
+            --status completed \
+            --json headSha \
+            -q '.[0].headSha' || true)
+
+          echo "Current SHA: $CURRENT_SHA"
+          if [ -n "$LAST_COMPLETED_SHA" ]; then
+            echo "Last completed run SHA: $LAST_COMPLETED_SHA"
+          else
+            echo "No completed runs found for workflow ${GITHUB_WORKFLOW} on branch ${GITHUB_REF_NAME}."
+          fi
+
+          if [ -n "$LAST_COMPLETED_SHA" ] && [ "$CURRENT_SHA" = "$LAST_COMPLETED_SHA" ]; then
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip integration tests when no new commits
+        if: github.event_name == 'schedule' && steps.commit-check.outputs.no_changes == 'true'
+        run: |
+          echo "No new commits since last nightly run, skipping integration tests"
+          exit 0
+
+      - name: Set up Python
+        if: github.event_name != 'schedule' || steps.commit-check.outputs.no_changes != 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        if: github.event_name != 'schedule' || steps.commit-check.outputs.no_changes != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run integration suite
+        if: github.event_name != 'schedule' || steps.commit-check.outputs.no_changes != 'true'
+        run: |
+          pytest -m integration -v

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,12 +1,17 @@
 name: CI Integration Tests
 
 on:
+  workflow_call:
+    secrets:
+      CONFLAGENT_DEV_URL:
+        required: true
+      CONFLAGENT_DEV_ENDPOINT:
+        required: true
+      CONFLAGENT_DEV_TOKEN:
+        required: true
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'
-  push:
-    branches:
-      - staging
 
 jobs:
   integration-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,13 @@
-name: CI Tests
+name: CI Unit Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      run_integration:
-        description: 'Toggle to run integration tests on this branch'
-        required: false
-        default: false
-        type: boolean
   push:
     branches:
-      - '**'
+      - main
+      - staging
+      - prod
   pull_request:
-  schedule:
-    - cron: '0 2 * * *'
 
 jobs:
   unit-tests:
@@ -37,83 +31,3 @@ jobs:
       - name: Run unit tests
         run: |
           pytest -m "not integration"
-
-  integration-tests:
-    name: Run integration tests against dev
-    runs-on: ubuntu-latest
-    needs: unit-tests
-    if: |
-      github.event_name != 'pull_request' &&
-      (
-        startsWith(github.ref, 'refs/heads/main') ||
-        startsWith(github.ref, 'refs/heads/staging') ||
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.run_integration == 'true')
-      )
-
-    env:
-      CONFLAGENT_DEV_URL: ${{ secrets.CONFLAGENT_DEV_URL }}
-      CONFLAGENT_DEV_ENDPOINT: ${{ secrets.CONFLAGENT_DEV_ENDPOINT }}
-      CONFLAGENT_DEV_TOKEN: ${{ secrets.CONFLAGENT_DEV_TOKEN }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Ensure GitHub CLI is installed
-        run: |
-          if ! command -v gh >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y gh
-          fi
-
-      - name: Check for commits since last completed run
-        id: commit-check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          CURRENT_SHA=$(git rev-parse HEAD)
-          LAST_COMPLETED_SHA=$(gh run list \
-            --workflow "$GITHUB_WORKFLOW" \
-            --branch "$GITHUB_REF_NAME" \
-            --status completed \
-            --json headSha \
-            -q '.[0].headSha' || true)
-
-          echo "Current SHA: $CURRENT_SHA"
-          if [ -n "$LAST_COMPLETED_SHA" ]; then
-            echo "Last completed run SHA: $LAST_COMPLETED_SHA"
-          else
-            echo "No completed runs found for workflow ${GITHUB_WORKFLOW} on branch ${GITHUB_REF_NAME}."
-          fi
-
-          if [ -n "$LAST_COMPLETED_SHA" ] && [ "$CURRENT_SHA" = "$LAST_COMPLETED_SHA" ]; then
-            echo "no_changes=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "no_changes=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Skip integration tests when no new commits
-        if: github.event_name == 'schedule' && steps.commit-check.outputs.no_changes == 'true'
-        run: |
-          echo "No new commits since last nightly run, skipping integration tests"
-          exit 0
-
-      - name: Set up Python
-        if: github.event_name != 'schedule' || steps.commit-check.outputs.no_changes != 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        if: github.event_name != 'schedule' || steps.commit-check.outputs.no_changes != 'true'
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run integration suite
-        if: github.event_name != 'schedule' || steps.commit-check.outputs.no_changes != 'true'
-        run: |
-          pytest -m integration -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,32 +2,8 @@ name: CI Unit Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - staging
-      - prod
   pull_request:
 
 jobs:
   unit-tests:
-    name: Run unit tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run unit tests
-        run: |
-          pytest -m "not integration"
+    uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,27 @@
+name: Unit Tests
+
+on:
+  workflow_call:
+
+jobs:
+  unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: |
+          pytest -m "not integration"


### PR DESCRIPTION
## Summary
- run unit tests on pull requests and pushes to deploy branches via a dedicated CI Unit Tests workflow
- add an integration test workflow that runs on demand, nightly, and when staging receives new commits
- update the deploy workflow to wait only for the unit test pipeline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690741024f6c832087c3ac17839d98f8