### PR TITLE
Refactor Conflagent app into modular services

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ It should be placed *outside* deployment folder.
 
 ```
 conflagent/
-├── conflagent.py                    # Flask application implementing the API
+├── conflagent.py                    # Flask routing entry point with lightweight handlers
+├── conflagent_core/                 # Core services for config, auth, OpenAPI, and Confluence access
 ├── conflagent.properties.example    # Example configuration file
 ├── openapi.json                     # OpenAPI 3.1 schema template used per endpoint
-├── tests/                           # Test suite covering all endpoints
+├── tests/                           # Unit and integration tests covering routes and services
 ```
 
 ## ⚙️ Setup & Deployment

--- a/conflagent.py
+++ b/conflagent.py
@@ -1,232 +1,75 @@
-from flask import Flask, request, jsonify, abort, send_file, g
-import requests
-import base64
-import os
-import json
-import copy
+"""Flask routing entry point for Conflagent."""
+
+from __future__ import annotations
+
+from flask import Flask, abort, g, jsonify, request
+
+from conflagent_core.auth import check_auth
+from conflagent_core.config import with_config
+from conflagent_core.confluence import ConfluenceClient
+from conflagent_core.openapi import generate_openapi_spec
+
 
 app = Flask(__name__)
-CONFIG_CACHE = {}
-
-def load_config(endpoint_name):
-    if endpoint_name in CONFIG_CACHE:
-        return CONFIG_CACHE[endpoint_name]
-
-    path = f"../conflagent.{endpoint_name}.properties"
-    if not os.path.exists(path):
-        abort(404, description=f"Configuration for endpoint '{endpoint_name}' not found")
-
-    config = {}
-    with open(path, "r") as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            key, sep, value = line.partition("=")
-            if sep:
-                config[key.strip()] = value.strip()
-
-    required_keys = ["email", "api_token", "base_url", "space_key", "root_page_id", "gpt_shared_secret"]
-    for key in required_keys:
-        if key not in config:
-            abort(500, description=f"Missing required config key '{key}' in {path}")
-
-    CONFIG_CACHE[endpoint_name] = config
-    return config
-
-def with_config(f):
-    def wrapped(endpoint_name, *args, **kwargs):
-        g.config = load_config(endpoint_name)
-        return f(endpoint_name, *args, **kwargs)
-    wrapped.__name__ = f.__name__
-    return wrapped
-
-def check_auth():
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        abort(403, description="Forbidden: Missing or invalid Authorization header")
-    token = auth_header.split("Bearer ")[-1].strip()
-    if token != g.config["gpt_shared_secret"]:
-        abort(403, description="Forbidden: Invalid bearer token")
-
-def build_headers():
-    token = f"{g.config['email']}:{g.config['api_token']}"
-    token_bytes = base64.b64encode(token.encode()).decode()
-    return {
-        "Authorization": f"Basic {token_bytes}",
-        "Content-Type": "application/json"
-    }
-
-def get_page_by_title(title, parent_id):
-    url = f"{g.config['base_url']}/rest/api/content/{parent_id}/child/page"
-    response = requests.get(url, headers=build_headers())
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    results = response.json().get("results", [])
-    for page in results:
-        if page["title"] == title:
-            return page
-    return None
-
-def resolve_or_create_path(path):
-    parts = path.strip("/").split("/")
-    current_parent_id = g.config['root_page_id']
-    for part in parts:
-        existing = get_page_by_title(part, current_parent_id)
-        if existing:
-            current_parent_id = existing["id"]
-        else:
-            payload = {
-                "type": "page",
-                "title": part,
-                "ancestors": [{"id": current_parent_id}],
-                "space": {"key": g.config['space_key']},
-                "body": {"storage": {"value": "", "representation": "storage"}}
-            }
-            url = f"{g.config['base_url']}/rest/api/content"
-            response = requests.post(url, headers=build_headers(), json=payload)
-            if response.status_code != 200:
-                abort(response.status_code, response.text)
-            current_parent_id = response.json()["id"]
-    return current_parent_id
-
-def list_pages_recursive(parent_id, prefix=""):
-    url = f"{g.config['base_url']}/rest/api/content/{parent_id}/child/page"
-    response = requests.get(url, headers=build_headers())
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    results = response.json().get("results", [])
-    paths = []
-    for page in results:
-        title = page["title"]
-        path = f"{prefix}/{title}" if prefix else title
-        paths.append(path)
-        paths.extend(list_pages_recursive(page["id"], path))
-    return paths
-
-def get_page_by_path(path):
-    parts = path.strip("/").split("/")
-    current_parent_id = g.config['root_page_id']
-    for part in parts:
-        page = get_page_by_title(part, current_parent_id)
-        if not page:
-            return None
-        current_parent_id = page["id"]
-    return page
-
-def get_page_body(page_id):
-    url = f"{g.config['base_url']}/rest/api/content/{page_id}?expand=body.storage"
-    response = requests.get(url, headers=build_headers())
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    return response.json()["body"]["storage"]["value"]
-
-def create_or_update_page(path, body):
-    parts = path.strip("/").split("/")
-    parent_path = "/".join(parts[:-1])
-    page_title = parts[-1]
-    parent_id = resolve_or_create_path(parent_path) if parent_path else g.config['root_page_id']
-    existing = get_page_by_title(page_title, parent_id)
-    if existing:
-        return update_page(existing, body)
-    payload = {
-        "type": "page",
-        "title": page_title,
-        "ancestors": [{"id": parent_id}],
-        "space": {"key": g.config['space_key']},
-        "body": {"storage": {"value": body, "representation": "storage"}}
-    }
-    url = f"{g.config['base_url']}/rest/api/content"
-    response = requests.post(url, headers=build_headers(), json=payload)
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    return {"message": "Page created", "id": response.json()["id"]}
-
-def update_page(page, new_body):
-    url = f"{g.config['base_url']}/rest/api/content/{page['id']}?expand=version"
-    response = requests.get(url, headers=build_headers())
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    version = response.json()["version"]["number"] + 1
-    payload = {
-        "id": page["id"],
-        "type": "page",
-        "title": page["title"],
-        "version": {"number": version},
-        "body": {"storage": {"value": new_body, "representation": "storage"}}
-    }
-    url = f"{g.config['base_url']}/rest/api/content/{page['id']}"
-    response = requests.put(url, headers=build_headers(), json=payload)
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    return {"message": "Page updated", "version": version}
-
-def rename_page(page, new_title):
-    url = f"{g.config['base_url']}/rest/api/content/{page['id']}?expand=version"
-    response = requests.get(url, headers=build_headers())
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    version = response.json()["version"]["number"] + 1
-
-    body = get_page_body(page["id"])  # <- fetch body content here
-
-    payload = {
-        "id": page["id"],
-        "type": "page",
-        "title": new_title,
-        "version": {"number": version},
-        "body": {"storage": {"value": body, "representation": "storage"}}
-    }
-    url = f"{g.config['base_url']}/rest/api/content/{page['id']}"
-    response = requests.put(url, headers=build_headers(), json=payload)
-    if response.status_code != 200:
-        abort(response.status_code, response.text)
-    return {"message": "Page renamed", "version": version}
 
 
-# === API Endpoints ===
+def _get_client() -> ConfluenceClient:
+    return ConfluenceClient(g.config)
+
 
 @app.route("/endpoint/<endpoint_name>/pages", methods=["GET"])
 @with_config
-def api_list_subpages(endpoint_name):
+def api_list_subpages(endpoint_name: str):  # pragma: no cover - exercised via tests
     check_auth()
-    return jsonify(list_pages_recursive(g.config['root_page_id']))
+    client = _get_client()
+    return jsonify(client.list_pages())
+
 
 @app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["GET"])
 @with_config
-def api_read_page(endpoint_name, title):
+def api_read_page(endpoint_name: str, title: str):
     check_auth()
-    page = get_page_by_path(title)
+    client = _get_client()
+    page = client.get_page_by_path(title)
     if not page:
         abort(404, description="Page not found")
-    content = get_page_body(page["id"])
+
+    content = client.get_page_body(page["id"])
     return jsonify({"title": title, "body": content})
+
 
 @app.route("/endpoint/<endpoint_name>/pages", methods=["POST"])
 @with_config
-def api_create_page(endpoint_name):
+def api_create_page(endpoint_name: str):
     check_auth()
     data = request.get_json(force=True)
     title = data.get("title")
     body = data.get("body", "")
     if not title:
         abort(400, description="Title is required")
-    return jsonify(create_or_update_page(title, body))
+
+    client = _get_client()
+    return jsonify(client.create_or_update_page(title, body))
+
 
 @app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["PUT"])
 @with_config
-def api_update_page(endpoint_name, title):
+def api_update_page(endpoint_name: str, title: str):
     check_auth()
     data = request.get_json(force=True)
     new_body = data.get("body", "")
-    page = get_page_by_path(title)
+
+    client = _get_client()
+    page = client.get_page_by_path(title)
     if not page:
         abort(404, description="Page not found")
-    return jsonify(update_page(page, new_body))
 
-@app.route('/endpoint/<endpoint_name>/pages/rename', methods=['POST'])
+    return jsonify(client.update_page(page, new_body))
+
+
+@app.route("/endpoint/<endpoint_name>/pages/rename", methods=["POST"])
 @with_config
-def api_rename_page(endpoint_name):
+def api_rename_page(endpoint_name: str):
     check_auth()
     data = request.get_json(force=True)
     old_title = data.get("old_title")
@@ -235,34 +78,29 @@ def api_rename_page(endpoint_name):
     if not old_title or not new_title:
         abort(400, description="Both 'old_title' and 'new_title' are required.")
 
-    page = get_page_by_path(old_title)
+    client = _get_client()
+    page = client.get_page_by_path(old_title)
     if not page:
         abort(404, description="Page not found")
 
-    result = rename_page(page, new_title)
-    result["new_title"] = new_title  # Ensure consistency for test expectations
+    result = client.rename_page(page, new_title)
+    result["new_title"] = new_title
     return jsonify(result)
 
 
 @app.route("/endpoint/<endpoint_name>/openapi.json", methods=["GET"])
 @with_config
-def openapi_schema(endpoint_name):
-    try:
-        with open("openapi.json", "r") as f:
-            template = json.load(f)
-    except Exception as e:
-        abort(500, description=f"Failed to load OpenAPI template: {e}")
-
-    spec = copy.deepcopy(template)
-    host_url = request.host_url.rstrip("/")
-    spec["servers"] = [{"url": f"{host_url}/endpoint/{endpoint_name}", "description": "Endpoint-specific API"}]
-
+def openapi_schema(endpoint_name: str):
+    spec = generate_openapi_spec(endpoint_name, request.host_url)
     return jsonify(spec)
+
 
 @app.route("/endpoint/<endpoint_name>/health", methods=["GET"])
 @with_config
-def api_health(endpoint_name):
+def api_health(endpoint_name: str):
     return jsonify({"status": "ok"})
 
-if __name__ == "__main__":
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
     app.run(host="0.0.0.0", port=5000)
+

--- a/conflagent_core/auth.py
+++ b/conflagent_core/auth.py
@@ -1,0 +1,18 @@
+"""Authentication helpers for Conflagent endpoints."""
+
+from __future__ import annotations
+
+from flask import abort, g, request
+
+
+def check_auth() -> None:
+    """Validate the bearer token provided in the request headers."""
+
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        abort(403, description="Forbidden: Missing or invalid Authorization header")
+
+    token = auth_header.split("Bearer ")[-1].strip()
+    if token != g.config["gpt_shared_secret"]:
+        abort(403, description="Forbidden: Invalid bearer token")
+

--- a/conflagent_core/config.py
+++ b/conflagent_core/config.py
@@ -1,0 +1,59 @@
+"""Configuration loading utilities for Conflagent."""
+
+from __future__ import annotations
+
+import os
+from functools import wraps
+from typing import Any, Callable, Dict
+
+from flask import abort, g
+
+
+CONFIG_CACHE: Dict[str, Dict[str, Any]] = {}
+
+
+def load_config(endpoint_name: str) -> Dict[str, Any]:
+    """Load configuration for the given endpoint from disk."""
+    if endpoint_name in CONFIG_CACHE:
+        return CONFIG_CACHE[endpoint_name]
+
+    path = f"../conflagent.{endpoint_name}.properties"
+    if not os.path.exists(path):
+        abort(404, description=f"Configuration for endpoint '{endpoint_name}' not found")
+
+    config: Dict[str, Any] = {}
+    with open(path, "r", encoding="utf-8") as file_handle:
+        for line in file_handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, sep, value = line.partition("=")
+            if sep:
+                config[key.strip()] = value.strip()
+
+    required_keys = [
+        "email",
+        "api_token",
+        "base_url",
+        "space_key",
+        "root_page_id",
+        "gpt_shared_secret",
+    ]
+    for key in required_keys:
+        if key not in config:
+            abort(500, description=f"Missing required config key '{key}' in {path}")
+
+    CONFIG_CACHE[endpoint_name] = config
+    return config
+
+
+def with_config(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator that injects endpoint configuration into the Flask global."""
+
+    @wraps(func)
+    def wrapper(endpoint_name: str, *args: Any, **kwargs: Any):
+        g.config = load_config(endpoint_name)
+        return func(endpoint_name, *args, **kwargs)
+
+    return wrapper
+

--- a/conflagent_core/confluence.py
+++ b/conflagent_core/confluence.py
@@ -1,0 +1,172 @@
+"""Confluence client for working with Conflagent routes."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Dict, List, Optional
+
+import requests
+from flask import abort
+
+
+class ConfluenceClient:
+    """A thin wrapper around the Confluence REST API."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self._config = config
+
+    # ------------------------------------------------------------------
+    # Convenience accessors
+    # ------------------------------------------------------------------
+    @property
+    def root_page_id(self) -> str:
+        return self._config["root_page_id"]
+
+    @property
+    def space_key(self) -> str:
+        return self._config["space_key"]
+
+    @property
+    def base_url(self) -> str:
+        return self._config["base_url"]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def build_headers(self) -> Dict[str, str]:
+        token = f"{self._config['email']}:{self._config['api_token']}"
+        token_bytes = base64.b64encode(token.encode()).decode()
+        return {
+            "Authorization": f"Basic {token_bytes}",
+            "Content-Type": "application/json",
+        }
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        response = requests.request(method, url, headers=self.build_headers(), **kwargs)
+        if response.status_code != 200:
+            abort(response.status_code, response.text)
+        return response
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def list_pages(self) -> List[str]:
+        return self._list_pages_recursive(self.root_page_id)
+
+    def _list_pages_recursive(self, parent_id: str, prefix: str = "") -> List[str]:
+        url = f"{self.base_url}/rest/api/content/{parent_id}/child/page"
+        response = self._request("get", url)
+        results = response.json().get("results", [])
+
+        paths: List[str] = []
+        for page in results:
+            title = page["title"]
+            current_path = f"{prefix}/{title}" if prefix else title
+            paths.append(current_path)
+            paths.extend(self._list_pages_recursive(page["id"], current_path))
+        return paths
+
+    def get_page_by_title(self, title: str, parent_id: str) -> Optional[Dict[str, Any]]:
+        url = f"{self.base_url}/rest/api/content/{parent_id}/child/page"
+        response = self._request("get", url)
+        results = response.json().get("results", [])
+        for page in results:
+            if page["title"] == title:
+                return page
+        return None
+
+    def resolve_or_create_path(self, path: str) -> str:
+        parts = path.strip("/").split("/") if path else []
+        current_parent_id = self.root_page_id
+        for part in parts:
+            existing = self.get_page_by_title(part, current_parent_id)
+            if existing:
+                current_parent_id = existing["id"]
+                continue
+
+            payload = {
+                "type": "page",
+                "title": part,
+                "ancestors": [{"id": current_parent_id}],
+                "space": {"key": self.space_key},
+                "body": {"storage": {"value": "", "representation": "storage"}},
+            }
+            url = f"{self.base_url}/rest/api/content"
+            response = self._request("post", url, json=payload)
+            current_parent_id = response.json()["id"]
+        return current_parent_id
+
+    def get_page_by_path(self, path: str) -> Optional[Dict[str, Any]]:
+        parts = path.strip("/").split("/")
+        current_parent_id = self.root_page_id
+        page: Optional[Dict[str, Any]] = None
+        for part in parts:
+            page = self.get_page_by_title(part, current_parent_id)
+            if not page:
+                return None
+            current_parent_id = page["id"]
+        return page
+
+    def get_page_body(self, page_id: str) -> str:
+        url = f"{self.base_url}/rest/api/content/{page_id}?expand=body.storage"
+        response = self._request("get", url)
+        return response.json()["body"]["storage"]["value"]
+
+    def create_or_update_page(self, path: str, body: str) -> Dict[str, Any]:
+        parts = path.strip("/").split("/")
+        parent_path = "/".join(parts[:-1])
+        page_title = parts[-1]
+        parent_id = (
+            self.resolve_or_create_path(parent_path)
+            if parent_path
+            else self.root_page_id
+        )
+        existing = self.get_page_by_title(page_title, parent_id)
+        if existing:
+            return self.update_page(existing, body)
+
+        payload = {
+            "type": "page",
+            "title": page_title,
+            "ancestors": [{"id": parent_id}],
+            "space": {"key": self.space_key},
+            "body": {"storage": {"value": body, "representation": "storage"}},
+        }
+        url = f"{self.base_url}/rest/api/content"
+        response = self._request("post", url, json=payload)
+        return {"message": "Page created", "id": response.json()["id"]}
+
+    def update_page(self, page: Dict[str, Any], new_body: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/content/{page['id']}?expand=version"
+        response = self._request("get", url)
+        version = response.json()["version"]["number"] + 1
+
+        payload = {
+            "id": page["id"],
+            "type": "page",
+            "title": page["title"],
+            "version": {"number": version},
+            "body": {"storage": {"value": new_body, "representation": "storage"}},
+        }
+        url = f"{self.base_url}/rest/api/content/{page['id']}"
+        self._request("put", url, json=payload)
+        return {"message": "Page updated", "version": version}
+
+    def rename_page(self, page: Dict[str, Any], new_title: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/content/{page['id']}?expand=version"
+        response = self._request("get", url)
+        version = response.json()["version"]["number"] + 1
+
+        body = self.get_page_body(page["id"])
+
+        payload = {
+            "id": page["id"],
+            "type": "page",
+            "title": new_title,
+            "version": {"number": version},
+            "body": {"storage": {"value": body, "representation": "storage"}},
+        }
+        url = f"{self.base_url}/rest/api/content/{page['id']}"
+        self._request("put", url, json=payload)
+        return {"message": "Page renamed", "version": version}
+

--- a/conflagent_core/openapi.py
+++ b/conflagent_core/openapi.py
@@ -1,0 +1,29 @@
+"""Utilities for serving the OpenAPI schema."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Dict
+
+from flask import abort
+
+
+def generate_openapi_spec(endpoint_name: str, host_url: str, template_path: str = "openapi.json") -> Dict[str, Any]:
+    """Generate a customised OpenAPI specification for an endpoint."""
+
+    try:
+        with open(template_path, "r", encoding="utf-8") as file_handle:
+            template = json.load(file_handle)
+    except Exception as exc:  # pragma: no cover - bubbled via abort
+        abort(500, description=f"Failed to load OpenAPI template: {exc}")
+
+    spec = copy.deepcopy(template)
+    spec["servers"] = [
+        {
+            "url": f"{host_url.rstrip('/')}/endpoint/{endpoint_name}",
+            "description": "Endpoint-specific API",
+        }
+    ]
+    return spec
+

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -23,42 +23,45 @@ mock_config = {
     "api_token": "b"
 }
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.list_pages_recursive")
-def test_list_pages(mock_list_pages, mock_load_config, client):
-    mock_list_pages.return_value = ["Path1/PageA", "Path2/PageB"]
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_list_pages(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.list_pages.return_value = ["Path1/PageA", "Path2/PageB"]
     response = client.get(f"/endpoint/{endpoint}/pages", headers=headers)
     assert response.status_code == 200
     assert response.get_json() == ["Path1/PageA", "Path2/PageB"]
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.get_page_by_path")
-@patch("conflagent.get_page_body")
-def test_read_page(mock_get_body, mock_get_page, mock_load_config, client):
-    mock_get_page.return_value = {"id": "123"}
-    mock_get_body.return_value = "Test content"
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_read_page(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = {"id": "123"}
+    mock_client.get_page_body.return_value = "Test content"
     response = client.get(f"/endpoint/{endpoint}/pages/some/page", headers=headers)
     assert response.status_code == 200
     assert response.get_json() == {"title": "some/page", "body": "Test content"}
 
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.get_page_by_path")
-def test_read_page_missing(mock_get_page, mock_load_config, client):
-    mock_get_page.return_value = None
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_read_page_missing(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = None
     response = client.get(f"/endpoint/{endpoint}/pages/missing", headers=headers)
     assert response.status_code == 404
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.create_or_update_page")
-def test_create_page(mock_create, mock_load_config, client):
-    mock_create.return_value = {"message": "Page created", "id": "456"}
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_create_page(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.create_or_update_page.return_value = {"message": "Page created", "id": "456"}
     response = client.post(f"/endpoint/{endpoint}/pages", json={"title": "some/page", "body": "new content"}, headers=headers)
     assert response.status_code == 200
     assert response.get_json() == {"message": "Page created", "id": "456"}
 
 
-@patch("conflagent.load_config", return_value=mock_config)
+@patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_create_page_requires_title(mock_load_config, client):
     response = client.post(
         f"/endpoint/{endpoint}/pages",
@@ -67,21 +70,22 @@ def test_create_page_requires_title(mock_load_config, client):
     )
     assert response.status_code == 400
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.get_page_by_path")
-@patch("conflagent.update_page")
-def test_update_page(mock_update, mock_get_page, mock_load_config, client):
-    mock_get_page.return_value = {"id": "789", "title": "some/page"}
-    mock_update.return_value = {"message": "Page updated", "version": 2}
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_update_page(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = {"id": "789", "title": "some/page"}
+    mock_client.update_page.return_value = {"message": "Page updated", "version": 2}
     response = client.put(f"/endpoint/{endpoint}/pages/some/page", json={"body": "updated content"}, headers=headers)
     assert response.status_code == 200
     assert response.get_json() == {"message": "Page updated", "version": 2}
 
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.get_page_by_path")
-def test_update_page_missing(mock_get_page, mock_load_config, client):
-    mock_get_page.return_value = None
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_update_page_missing(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = None
     response = client.put(
         f"/endpoint/{endpoint}/pages/missing",
         json={"body": "updated"},
@@ -89,18 +93,18 @@ def test_update_page_missing(mock_get_page, mock_load_config, client):
     )
     assert response.status_code == 404
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.get_page_by_path")
-@patch("conflagent.rename_page")
-def test_rename_page(mock_rename, mock_get_page, mock_load_config, client):
-    mock_get_page.return_value = {"id": "111", "title": "old/page"}
-    mock_rename.return_value = {"message": "Page renamed", "new_title": "new/page"}
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_rename_page(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = {"id": "111", "title": "old/page"}
+    mock_client.rename_page.return_value = {"message": "Page renamed", "version": 2}
     response = client.post(f"/endpoint/{endpoint}/pages/rename", json={"old_title": "old/page", "new_title": "new/page"}, headers=headers)
     assert response.status_code == 200
-    assert response.get_json() == {"message": "Page renamed", "new_title": "new/page"}
+    assert response.get_json() == {"message": "Page renamed", "new_title": "new/page", "version": 2}
 
 
-@patch("conflagent.load_config", return_value=mock_config)
+@patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_rename_page_requires_fields(mock_load_config, client):
     response = client.post(
         f"/endpoint/{endpoint}/pages/rename",
@@ -110,10 +114,11 @@ def test_rename_page_requires_fields(mock_load_config, client):
     assert response.status_code == 400
 
 
-@patch("conflagent.load_config", return_value=mock_config)
-@patch("conflagent.get_page_by_path")
-def test_rename_page_missing_source(mock_get_page, mock_load_config, client):
-    mock_get_page.return_value = None
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_rename_page_missing_source(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = None
     response = client.post(
         f"/endpoint/{endpoint}/pages/rename",
         json={"old_title": "missing", "new_title": "new"},
@@ -121,13 +126,13 @@ def test_rename_page_missing_source(mock_get_page, mock_load_config, client):
     )
     assert response.status_code == 404
 
-@patch("conflagent.load_config", return_value=mock_config)
+@patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_health(mock_load_config, client):
     response = client.get(f"/endpoint/{endpoint}/health")
     assert response.status_code == 200
     assert response.get_json()["status"] == "ok"
 
-@patch("conflagent.load_config", return_value=mock_config)
+@patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_openapi_schema(mock_load_config, client):
     response = client.get(f"/endpoint/{endpoint}/openapi.json")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- extract configuration, authentication, and Confluence client logic into a new conflagent_core package
- slim the Flask routing module so each endpoint delegates to the new ConfluenceClient service
- update unit tests to cover the refactored modules and patched entry points

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690798cf55ac8320b343a31d7c4476ce