### PR TITLE
Automate OpenAPI specification generation

### DIFF
--- a/conflagent.py
+++ b/conflagent.py
@@ -7,7 +7,11 @@ from flask import Flask, abort, g, jsonify, request
 from conflagent_core.auth import check_auth
 from conflagent_core.config import with_config
 from conflagent_core.confluence import ConfluenceClient
-from conflagent_core.openapi import document_operation, generate_openapi_spec
+from conflagent_core.openapi import (
+    BEARER_SECURITY_REQUIREMENT,
+    document_operation,
+    generate_openapi_spec,
+)
 
 
 app = Flask(__name__)
@@ -19,7 +23,31 @@ def _get_client() -> ConfluenceClient:
 
 @app.route("/endpoint/<endpoint_name>/pages", methods=["GET"])
 @with_config
-@document_operation("/pages", "get")
+@document_operation(
+    "/pages",
+    "get",
+    summary="List subpages of the root page",
+    description=(
+        "Returns the titles of all pages that are direct children of the configured "
+        "root page in the Confluence space."
+    ),
+    operationId="listSubpages",
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "List of subpages",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    }
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+    },
+)
 def api_list_subpages(endpoint_name: str):  # pragma: no cover - exercised via tests
     check_auth()
     client = _get_client()
@@ -28,7 +56,52 @@ def api_list_subpages(endpoint_name: str):  # pragma: no cover - exercised via t
 
 @app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["GET"])
 @with_config
-@document_operation("/pages/{title}", "get")
+@document_operation(
+    "/pages/{title}",
+    "get",
+    summary="Read content of a page by title",
+    description=(
+        "Returns the content of a Confluence page identified by title (must be a "
+        "direct child of root). Content is returned in Confluence storage format "
+        "(HTML-like XML). When reading content, be careful not to mangle internal "
+        "page links in subsequent updates."
+    ),
+    operationId="readPageByTitle",
+    parameters=[
+        {
+            "name": "title",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+        }
+    ],
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "Page content returned",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "body": {
+                                "type": "string",
+                                "description": (
+                                    "Content in Confluence storage format (HTML-like XML)."
+                                ),
+                            },
+                        },
+                    }
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {
+            "description": "Not Found: Page not found or not a child of root"
+        },
+    },
+)
 def api_read_page(endpoint_name: str, title: str):
     check_auth()
     client = _get_client()
@@ -42,7 +115,59 @@ def api_read_page(endpoint_name: str, title: str):
 
 @app.route("/endpoint/<endpoint_name>/pages", methods=["POST"])
 @with_config
-@document_operation("/pages", "post")
+@document_operation(
+    "/pages",
+    "post",
+    summary="Create a new child page under root",
+    description=(
+        "Creates a new Confluence page as a direct child of the configured root "
+        "page. Title must be unique under the root. Body may contain Markdown — "
+        "it will be converted to Confluence storage format automatically."
+    ),
+    operationId="createPage",
+    security=BEARER_SECURITY_REQUIREMENT,
+    requestBody={
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["title"],
+                    "properties": {
+                        "title": {"type": "string"},
+                        "body": {
+                            "type": "string",
+                            "description": (
+                                "Optional Markdown body — will be converted to "
+                                "Confluence HTML format."
+                            ),
+                        },
+                    },
+                }
+            }
+        },
+    },
+    responses={
+        "200": {
+            "description": "Page created successfully",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"},
+                            "id": {"type": "string"},
+                        },
+                    }
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "409": {
+            "description": "Conflict: Page with this title already exists under root"
+        },
+    },
+)
 def api_create_page(endpoint_name: str):
     check_auth()
     data = request.get_json(force=True)
@@ -57,7 +182,69 @@ def api_create_page(endpoint_name: str):
 
 @app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["PUT"])
 @with_config
-@document_operation("/pages/{title}", "put")
+@document_operation(
+    "/pages/{title}",
+    "put",
+    summary="Update content of a page by title",
+    description=(
+        "Updates the full content of a Confluence page identified by title. Only "
+        "pages under the configured root are updatable. Markdown input is "
+        "accepted and will be converted on the fly to Confluence storage format "
+        "(HTML/XML). ⚠️ Full body content must be submitted — partial/diff "
+        "updates are not supported."
+    ),
+    operationId="updatePageByTitle",
+    parameters=[
+        {
+            "name": "title",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+        }
+    ],
+    security=BEARER_SECURITY_REQUIREMENT,
+    requestBody={
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["body"],
+                    "properties": {
+                        "body": {
+                            "type": "string",
+                            "description": (
+                                "Markdown content to be converted to Confluence "
+                                "HTML. Submit full content only — diffs/patches "
+                                "are not supported."
+                            ),
+                        },
+                    },
+                }
+            }
+        },
+    },
+    responses={
+        "200": {
+            "description": "Page updated successfully",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"},
+                            "version": {"type": "integer"},
+                        },
+                    }
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {
+            "description": "Not Found: Page not found or not a child of root"
+        },
+    },
+)
 def api_update_page(endpoint_name: str, title: str):
     check_auth()
     data = request.get_json(force=True)
@@ -73,7 +260,53 @@ def api_update_page(endpoint_name: str, title: str):
 
 @app.route("/endpoint/<endpoint_name>/pages/rename", methods=["POST"])
 @with_config
-@document_operation("/pages/rename", "post")
+@document_operation(
+    "/pages/rename",
+    "post",
+    summary="Rename a page by title",
+    description=(
+        "Renames a page by changing its title. The page must be a direct child of "
+        "the configured root page. Title change is immediate and does not alter "
+        "page hierarchy."
+    ),
+    operationId="renamePage",
+    security=BEARER_SECURITY_REQUIREMENT,
+    requestBody={
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["old_title", "new_title"],
+                    "properties": {
+                        "old_title": {"type": "string"},
+                        "new_title": {"type": "string"},
+                    },
+                }
+            }
+        },
+    },
+    responses={
+        "200": {
+            "description": "Page renamed successfully",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"},
+                            "new_title": {"type": "string"},
+                        },
+                    }
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {
+            "description": "Not Found: Page not found or not a child of root"
+        },
+    },
+)
 def api_rename_page(endpoint_name: str):
     check_auth()
     data = request.get_json(force=True)
@@ -95,7 +328,23 @@ def api_rename_page(endpoint_name: str):
 
 @app.route("/endpoint/<endpoint_name>/openapi.json", methods=["GET"])
 @with_config
-@document_operation("/openapi.json", "get")
+@document_operation(
+    "/openapi.json",
+    "get",
+    summary="Get OpenAPI schema",
+    description="Returns this OpenAPI schema document.",
+    operationId="getOpenAPISchema",
+    responses={
+        "200": {
+            "description": "OpenAPI JSON returned",
+            "content": {
+                "application/json": {
+                    "schema": {"type": "object", "properties": {}},
+                }
+            },
+        }
+    },
+)
 def openapi_schema(endpoint_name: str):
     spec = generate_openapi_spec(endpoint_name, request.host_url, app)
     return jsonify(spec)
@@ -103,7 +352,28 @@ def openapi_schema(endpoint_name: str):
 
 @app.route("/endpoint/<endpoint_name>/health", methods=["GET"])
 @with_config
-@document_operation("/health", "get")
+@document_operation(
+    "/health",
+    "get",
+    summary="Health check",
+    description="Check whether API server is live. No authentication required.",
+    operationId="healthCheck",
+    responses={
+        "200": {
+            "description": "Server is running",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "status": {"type": "string", "example": "ok"},
+                        },
+                    }
+                }
+            },
+        }
+    },
+)
 def api_health(endpoint_name: str):
     return jsonify({"status": "ok"})
 

--- a/conflagent.py
+++ b/conflagent.py
@@ -7,7 +7,7 @@ from flask import Flask, abort, g, jsonify, request
 from conflagent_core.auth import check_auth
 from conflagent_core.config import with_config
 from conflagent_core.confluence import ConfluenceClient
-from conflagent_core.openapi import generate_openapi_spec
+from conflagent_core.openapi import document_operation, generate_openapi_spec
 
 
 app = Flask(__name__)
@@ -19,6 +19,7 @@ def _get_client() -> ConfluenceClient:
 
 @app.route("/endpoint/<endpoint_name>/pages", methods=["GET"])
 @with_config
+@document_operation("/pages", "get")
 def api_list_subpages(endpoint_name: str):  # pragma: no cover - exercised via tests
     check_auth()
     client = _get_client()
@@ -27,6 +28,7 @@ def api_list_subpages(endpoint_name: str):  # pragma: no cover - exercised via t
 
 @app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["GET"])
 @with_config
+@document_operation("/pages/{title}", "get")
 def api_read_page(endpoint_name: str, title: str):
     check_auth()
     client = _get_client()
@@ -40,6 +42,7 @@ def api_read_page(endpoint_name: str, title: str):
 
 @app.route("/endpoint/<endpoint_name>/pages", methods=["POST"])
 @with_config
+@document_operation("/pages", "post")
 def api_create_page(endpoint_name: str):
     check_auth()
     data = request.get_json(force=True)
@@ -54,6 +57,7 @@ def api_create_page(endpoint_name: str):
 
 @app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["PUT"])
 @with_config
+@document_operation("/pages/{title}", "put")
 def api_update_page(endpoint_name: str, title: str):
     check_auth()
     data = request.get_json(force=True)
@@ -69,6 +73,7 @@ def api_update_page(endpoint_name: str, title: str):
 
 @app.route("/endpoint/<endpoint_name>/pages/rename", methods=["POST"])
 @with_config
+@document_operation("/pages/rename", "post")
 def api_rename_page(endpoint_name: str):
     check_auth()
     data = request.get_json(force=True)
@@ -90,13 +95,15 @@ def api_rename_page(endpoint_name: str):
 
 @app.route("/endpoint/<endpoint_name>/openapi.json", methods=["GET"])
 @with_config
+@document_operation("/openapi.json", "get")
 def openapi_schema(endpoint_name: str):
-    spec = generate_openapi_spec(endpoint_name, request.host_url)
+    spec = generate_openapi_spec(endpoint_name, request.host_url, app)
     return jsonify(spec)
 
 
 @app.route("/endpoint/<endpoint_name>/health", methods=["GET"])
 @with_config
+@document_operation("/health", "get")
 def api_health(endpoint_name: str):
     return jsonify({"status": "ok"})
 

--- a/conflagent_core/openapi.py
+++ b/conflagent_core/openapi.py
@@ -2,23 +2,295 @@
 
 from __future__ import annotations
 
-import copy
-import json
 from typing import Any, Dict
 
+from apispec import APISpec
 from flask import abort
 
+_API_DESCRIPTION = (
+    "REST API bridge between Custom GPTs and a sandboxed Confluence root page. "
+    "All requests must be authenticated using a Bearer token (Authorization: Bearer <token>). "
+    "API enables programmatic listing, reading, creation, updating, and renaming of Confluence pages "
+    "under a pre-defined root page."
+)
 
-def generate_openapi_spec(endpoint_name: str, host_url: str, template_path: str = "openapi.json") -> Dict[str, Any]:
+_BEARER_SECURITY_REQUIREMENT = [{"BearerAuth": []}]
+
+_PATH_DEFINITIONS: Dict[str, Dict[str, Any]] = {
+    "/pages": {
+        "get": {
+            "summary": "List subpages of the root page",
+            "description": "Returns the titles of all pages that are direct children of the configured root page in the Confluence space.",
+            "operationId": "listSubpages",
+            "security": _BEARER_SECURITY_REQUIREMENT,
+            "responses": {
+                "200": {
+                    "description": "List of subpages",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            }
+                        }
+                    },
+                },
+                "403": {"description": "Forbidden: Invalid token"},
+            },
+        },
+        "post": {
+            "summary": "Create a new child page under root",
+            "description": "Creates a new Confluence page as a direct child of the configured root page. Title must be unique under the root. Body may contain Markdown — it will be converted to Confluence storage format automatically.",
+            "operationId": "createPage",
+            "security": _BEARER_SECURITY_REQUIREMENT,
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["title"],
+                            "properties": {
+                                "title": {"type": "string"},
+                                "body": {
+                                    "type": "string",
+                                    "description": "Optional Markdown body — will be converted to Confluence HTML format.",
+                                },
+                            },
+                        }
+                    }
+                },
+            },
+            "responses": {
+                "200": {
+                    "description": "Page created successfully",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "message": {"type": "string"},
+                                    "id": {"type": "string"},
+                                },
+                            }
+                        }
+                    },
+                },
+                "403": {"description": "Forbidden: Invalid token"},
+                "409": {
+                    "description": "Conflict: Page with this title already exists under root"
+                },
+            },
+        },
+    },
+    "/pages/{title}": {
+        "get": {
+            "summary": "Read content of a page by title",
+            "description": "Returns the content of a Confluence page identified by title (must be a direct child of root). Content is returned in Confluence storage format (HTML-like XML). When reading content, be careful not to mangle internal page links in subsequent updates.",
+            "operationId": "readPageByTitle",
+            "parameters": [
+                {
+                    "name": "title",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+            "security": _BEARER_SECURITY_REQUIREMENT,
+            "responses": {
+                "200": {
+                    "description": "Page content returned",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "title": {"type": "string"},
+                                    "body": {
+                                        "type": "string",
+                                        "description": "Content in Confluence storage format (HTML-like XML).",
+                                    },
+                                },
+                            }
+                        }
+                    },
+                },
+                "403": {"description": "Forbidden: Invalid token"},
+                "404": {
+                    "description": "Not Found: Page not found or not a child of root"
+                },
+            },
+        },
+        "put": {
+            "summary": "Update content of a page by title",
+            "description": "Updates the full content of a Confluence page identified by title. Only pages under the configured root are updatable. Markdown input is accepted and will be converted on the fly to Confluence storage format (HTML/XML). ⚠️ Full body content must be submitted — partial/diff updates are not supported.",
+            "operationId": "updatePageByTitle",
+            "parameters": [
+                {
+                    "name": "title",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+            "security": _BEARER_SECURITY_REQUIREMENT,
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["body"],
+                            "properties": {
+                                "body": {
+                                    "type": "string",
+                                    "description": "Markdown content to be converted to Confluence HTML. Submit full content only — diffs/patches are not supported.",
+                                },
+                            },
+                        }
+                    }
+                },
+            },
+            "responses": {
+                "200": {
+                    "description": "Page updated successfully",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "message": {"type": "string"},
+                                    "version": {"type": "integer"},
+                                },
+                            }
+                        }
+                    },
+                },
+                "403": {"description": "Forbidden: Invalid token"},
+                "404": {
+                    "description": "Not Found: Page not found or not a child of root"
+                },
+            },
+        },
+    },
+    "/pages/rename": {
+        "post": {
+            "summary": "Rename a page by title",
+            "description": "Renames a page by changing its title. The page must be a direct child of the configured root page. Title change is immediate and does not alter page hierarchy.",
+            "operationId": "renamePage",
+            "security": _BEARER_SECURITY_REQUIREMENT,
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["old_title", "new_title"],
+                            "properties": {
+                                "old_title": {"type": "string"},
+                                "new_title": {"type": "string"},
+                            },
+                        }
+                    }
+                },
+            },
+            "responses": {
+                "200": {
+                    "description": "Page renamed successfully",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "message": {"type": "string"},
+                                    "new_title": {"type": "string"},
+                                },
+                            }
+                        }
+                    },
+                },
+                "403": {"description": "Forbidden: Invalid token"},
+                "404": {
+                    "description": "Not Found: Page not found or not a child of root"
+                },
+            },
+        }
+    },
+    "/health": {
+        "get": {
+            "summary": "Health check",
+            "description": "Check whether API server is live. No authentication required.",
+            "operationId": "healthCheck",
+            "responses": {
+                "200": {
+                    "description": "Server is running",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "status": {"type": "string", "example": "ok"},
+                                },
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    },
+    "/openapi.json": {
+        "get": {
+            "summary": "Get OpenAPI schema",
+            "description": "Returns this OpenAPI schema document.",
+            "operationId": "getOpenAPISchema",
+            "responses": {
+                "200": {
+                    "description": "OpenAPI JSON returned",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {},
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    },
+}
+
+
+def _build_spec() -> APISpec:
+    spec = APISpec(
+        title="Conflagent API",
+        version="2.2.0",
+        openapi_version="3.1.0",
+        info={"description": _API_DESCRIPTION},
+    )
+
+    spec.components.security_scheme(
+        "BearerAuth",
+        {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"},
+    )
+
+    for path, operations in _PATH_DEFINITIONS.items():
+        spec.path(path=path, operations=operations)
+
+    return spec
+
+
+def generate_openapi_spec(
+    endpoint_name: str, host_url: str, template_path: str = "openapi.json"
+) -> Dict[str, Any]:
     """Generate a customised OpenAPI specification for an endpoint."""
 
     try:
-        with open(template_path, "r", encoding="utf-8") as file_handle:
-            template = json.load(file_handle)
+        spec = _build_spec().to_dict()
     except Exception as exc:  # pragma: no cover - bubbled via abort
-        abort(500, description=f"Failed to load OpenAPI template: {exc}")
+        abort(500, description=f"Failed to build OpenAPI specification: {exc}")
 
-    spec = copy.deepcopy(template)
+    spec.setdefault("components", {}).setdefault("schemas", {})
     spec["servers"] = [
         {
             "url": f"{host_url.rstrip('/')}/endpoint/{endpoint_name}",

--- a/conflagent_core/openapi.py
+++ b/conflagent_core/openapi.py
@@ -15,261 +15,26 @@ _API_DESCRIPTION = (
     "under a pre-defined root page."
 )
 
-_BEARER_SECURITY_REQUIREMENT = [{"BearerAuth": []}]
+BEARER_SECURITY_REQUIREMENT = [{"BearerAuth": []}]
 
-_PATH_DEFINITIONS: Dict[str, Dict[str, Any]] = {
-    "/pages": {
-        "get": {
-            "summary": "List subpages of the root page",
-            "description": "Returns the titles of all pages that are direct children of the configured root page in the Confluence space.",
-            "operationId": "listSubpages",
-            "security": _BEARER_SECURITY_REQUIREMENT,
-            "responses": {
-                "200": {
-                    "description": "List of subpages",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                            }
-                        }
-                    },
-                },
-                "403": {"description": "Forbidden: Invalid token"},
-            },
-        },
-        "post": {
-            "summary": "Create a new child page under root",
-            "description": "Creates a new Confluence page as a direct child of the configured root page. Title must be unique under the root. Body may contain Markdown — it will be converted to Confluence storage format automatically.",
-            "operationId": "createPage",
-            "security": _BEARER_SECURITY_REQUIREMENT,
-            "requestBody": {
-                "required": True,
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "type": "object",
-                            "required": ["title"],
-                            "properties": {
-                                "title": {"type": "string"},
-                                "body": {
-                                    "type": "string",
-                                    "description": "Optional Markdown body — will be converted to Confluence HTML format.",
-                                },
-                            },
-                        }
-                    }
-                },
-            },
-            "responses": {
-                "200": {
-                    "description": "Page created successfully",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {"type": "string"},
-                                    "id": {"type": "string"},
-                                },
-                            }
-                        }
-                    },
-                },
-                "403": {"description": "Forbidden: Invalid token"},
-                "409": {
-                    "description": "Conflict: Page with this title already exists under root"
-                },
-            },
-        },
-    },
-    "/pages/{title}": {
-        "get": {
-            "summary": "Read content of a page by title",
-            "description": "Returns the content of a Confluence page identified by title (must be a direct child of root). Content is returned in Confluence storage format (HTML-like XML). When reading content, be careful not to mangle internal page links in subsequent updates.",
-            "operationId": "readPageByTitle",
-            "parameters": [
-                {
-                    "name": "title",
-                    "in": "path",
-                    "required": True,
-                    "schema": {"type": "string"},
-                }
-            ],
-            "security": _BEARER_SECURITY_REQUIREMENT,
-            "responses": {
-                "200": {
-                    "description": "Page content returned",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "title": {"type": "string"},
-                                    "body": {
-                                        "type": "string",
-                                        "description": "Content in Confluence storage format (HTML-like XML).",
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "403": {"description": "Forbidden: Invalid token"},
-                "404": {
-                    "description": "Not Found: Page not found or not a child of root"
-                },
-            },
-        },
-        "put": {
-            "summary": "Update content of a page by title",
-            "description": "Updates the full content of a Confluence page identified by title. Only pages under the configured root are updatable. Markdown input is accepted and will be converted on the fly to Confluence storage format (HTML/XML). ⚠️ Full body content must be submitted — partial/diff updates are not supported.",
-            "operationId": "updatePageByTitle",
-            "parameters": [
-                {
-                    "name": "title",
-                    "in": "path",
-                    "required": True,
-                    "schema": {"type": "string"},
-                }
-            ],
-            "security": _BEARER_SECURITY_REQUIREMENT,
-            "requestBody": {
-                "required": True,
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "type": "object",
-                            "required": ["body"],
-                            "properties": {
-                                "body": {
-                                    "type": "string",
-                                    "description": "Markdown content to be converted to Confluence HTML. Submit full content only — diffs/patches are not supported.",
-                                },
-                            },
-                        }
-                    }
-                },
-            },
-            "responses": {
-                "200": {
-                    "description": "Page updated successfully",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {"type": "string"},
-                                    "version": {"type": "integer"},
-                                },
-                            }
-                        }
-                    },
-                },
-                "403": {"description": "Forbidden: Invalid token"},
-                "404": {
-                    "description": "Not Found: Page not found or not a child of root"
-                },
-            },
-        },
-    },
-    "/pages/rename": {
-        "post": {
-            "summary": "Rename a page by title",
-            "description": "Renames a page by changing its title. The page must be a direct child of the configured root page. Title change is immediate and does not alter page hierarchy.",
-            "operationId": "renamePage",
-            "security": _BEARER_SECURITY_REQUIREMENT,
-            "requestBody": {
-                "required": True,
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "type": "object",
-                            "required": ["old_title", "new_title"],
-                            "properties": {
-                                "old_title": {"type": "string"},
-                                "new_title": {"type": "string"},
-                            },
-                        }
-                    }
-                },
-            },
-            "responses": {
-                "200": {
-                    "description": "Page renamed successfully",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {"type": "string"},
-                                    "new_title": {"type": "string"},
-                                },
-                            }
-                        }
-                    },
-                },
-                "403": {"description": "Forbidden: Invalid token"},
-                "404": {
-                    "description": "Not Found: Page not found or not a child of root"
-                },
-            },
-        }
-    },
-    "/health": {
-        "get": {
-            "summary": "Health check",
-            "description": "Check whether API server is live. No authentication required.",
-            "operationId": "healthCheck",
-            "responses": {
-                "200": {
-                    "description": "Server is running",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "status": {"type": "string", "example": "ok"},
-                                },
-                            }
-                        }
-                    },
-                }
-            },
-        }
-    },
-    "/openapi.json": {
-        "get": {
-            "summary": "Get OpenAPI schema",
-            "description": "Returns this OpenAPI schema document.",
-            "operationId": "getOpenAPISchema",
-            "responses": {
-                "200": {
-                    "description": "OpenAPI JSON returned",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {},
-                            }
-                        }
-                    },
-                }
-            },
-        }
-    },
-}
+def document_operation(
+    path: str,
+    method: str,
+    **operation: Any,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Attach an OpenAPI definition to a Flask view function.
 
+    The decorator stores the provided OpenAPI operation object on the wrapped
+    function so the generator can harvest them at runtime.
+    """
 
-def document_operation(path: str, method: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Attach an OpenAPI definition to a Flask view function."""
+    if not operation:
+        raise ValueError(
+            f"OpenAPI operation for {method.upper()} {path} must define at least one field"
+        )
 
     normalised_method = method.lower()
-    if path not in _PATH_DEFINITIONS or normalised_method not in _PATH_DEFINITIONS[path]:
-        raise KeyError(f"Unknown OpenAPI definition for {method.upper()} {path}")
-
-    definition = copy.deepcopy(_PATH_DEFINITIONS[path][normalised_method])
+    definition = copy.deepcopy(operation)
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         docs: Dict[str, Dict[str, Any]] = getattr(func, "__openapi__", {})
@@ -278,7 +43,7 @@ def document_operation(path: str, method: str) -> Callable[[Callable[..., Any]],
             raise ValueError(
                 f"Duplicate OpenAPI definition for {method.upper()} {path} on {func.__name__}"
             )
-        path_docs[normalised_method] = definition
+        path_docs[normalised_method] = copy.deepcopy(definition)
         setattr(func, "__openapi__", docs)
         return func
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
 pytest
+apispec

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -6,6 +6,7 @@ import copy
 import json
 from pathlib import Path
 
+from conflagent import app
 from conflagent_core.openapi import generate_openapi_spec
 
 
@@ -17,7 +18,7 @@ def test_generated_spec_matches_template():
 
     endpoint_name = "demo"
     host_url = "https://example.test/"
-    generated = generate_openapi_spec(endpoint_name, host_url)
+    generated = generate_openapi_spec(endpoint_name, host_url, app)
 
     expected = copy.deepcopy(template)
     expected["servers"] = [

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -1,0 +1,31 @@
+"""Tests for generated OpenAPI specification."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from conflagent_core.openapi import generate_openapi_spec
+
+
+def test_generated_spec_matches_template():
+    """The generated spec should match the checked-in template aside from server URL."""
+
+    template_path = Path("openapi.json")
+    template = json.loads(template_path.read_text(encoding="utf-8"))
+
+    endpoint_name = "demo"
+    host_url = "https://example.test/"
+    generated = generate_openapi_spec(endpoint_name, host_url)
+
+    expected = copy.deepcopy(template)
+    expected["servers"] = [
+        {
+            "url": f"{host_url.rstrip('/')}/endpoint/{endpoint_name}",
+            "description": "Endpoint-specific API",
+        }
+    ]
+
+    assert generated == expected
+


### PR DESCRIPTION
## Summary
- build the OpenAPI schema via apispec with in-code path definitions
- add apispec to the runtime dependencies
- cover the generator with a regression test against the checked-in template

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6907a4ad5058832089ebce2a9772124f