### PR TITLE
Refine CI workflows for testing and deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,24 +7,49 @@ on:
       - staging
       - prod
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment for manual deployments'
+        type: choice
+        options:
+          - dev
+          - stage
+          - production
+        default: dev
 
 jobs:
   run-unit-tests:
     uses: ./.github/workflows/unit-tests.yml
 
   run-integration-tests:
-    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/prod'
+    if: |
+      github.ref == 'refs/heads/staging' ||
+      github.ref == 'refs/heads/prod' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.environment == 'stage' || inputs.environment == 'production'))
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 
   deploy:
     name: Deploy application
-    needs: run-unit-tests
+    needs:
+      - run-unit-tests
+      - run-integration-tests
     runs-on: ubuntu-latest
     if: >-
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/staging' ||
-      github.ref == 'refs/heads/prod'
+      (
+        github.event_name == 'push' && (
+          github.ref == 'refs/heads/main' ||
+          github.ref == 'refs/heads/staging' ||
+          github.ref == 'refs/heads/prod'
+        )
+      ) || (
+        github.event_name == 'workflow_dispatch' && inputs.environment == 'dev'
+      )
+      && needs.run-unit-tests.result == 'success'
+      && (
+        needs.run-integration-tests.result == 'success' ||
+        needs.run-integration-tests.result == 'skipped'
+      )
 
     steps:
       - name: Checkout repository
@@ -39,24 +64,35 @@ jobs:
         id: env
         env:
           TARGET_BRANCH: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || '' }}
         run: |
           BRANCH="$TARGET_BRANCH"
-          case "$BRANCH" in
-            main)
-              ENV_NAME="dev"
-              ;;
-            staging)
-              ENV_NAME="stage"
-              ;;
-            prod)
-              ENV_NAME="production"
-              ;;
-            *)
-              echo "❌ Unknown branch: $BRANCH"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$DISPATCH_ENV" != "dev" ] && [ "$DISPATCH_ENV" != "stage" ] && [ "$DISPATCH_ENV" != "production" ]; then
+              echo "❌ Unsupported manual environment: $DISPATCH_ENV"
               exit 1
-              ;;
-          esac
-          echo "env=${ENV_NAME}" >> $GITHUB_OUTPUT
+            fi
+            ENV_NAME="$DISPATCH_ENV"
+          else
+            case "$BRANCH" in
+              main)
+                ENV_NAME="dev"
+                ;;
+              staging)
+                ENV_NAME="stage"
+                ;;
+              prod)
+                ENV_NAME="production"
+                ;;
+              *)
+                echo "❌ Unknown branch: $BRANCH"
+                exit 1
+                ;;
+            esac
+          fi
+
+          echo "env=${ENV_NAME}" >> "$GITHUB_OUTPUT"
           echo "✅ Will deploy branch '$BRANCH' → environment '$ENV_NAME'"
 
       - name: Add known host

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,14 +36,17 @@ jobs:
       - run-integration-tests
     runs-on: ubuntu-latest
     if: >-
+      always() &&
       (
-        github.event_name == 'push' && (
-          github.ref == 'refs/heads/main' ||
-          github.ref == 'refs/heads/staging' ||
-          github.ref == 'refs/heads/prod'
+        (
+          github.event_name == 'push' && (
+            github.ref == 'refs/heads/main' ||
+            github.ref == 'refs/heads/staging' ||
+            github.ref == 'refs/heads/prod'
+          )
+        ) || (
+          github.event_name == 'workflow_dispatch' && inputs.environment == 'dev'
         )
-      ) || (
-        github.event_name == 'workflow_dispatch' && inputs.environment == 'dev'
       )
       && needs.run-unit-tests.result == 'success'
       && (

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,9 @@ on:
       CONFLAGENT_DEV_TOKEN:
         required: true
   workflow_dispatch:
+  pull_request:
+    branches:
+      - staging
   schedule:
     - cron: '0 2 * * *'
 
@@ -17,6 +20,7 @@ jobs:
   integration-tests:
     name: Run integration tests against dev
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     env:
       CONFLAGENT_DEV_URL: ${{ secrets.CONFLAGENT_DEV_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,0 @@
-name: CI Unit Tests
-
-on:
-  workflow_dispatch:
-  pull_request:
-
-jobs:
-  unit-tests:
-    uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,8 @@ name: Unit Tests
 
 on:
   workflow_call:
+  workflow_dispatch:
+  pull_request:
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary
- trigger the reusable unit-test workflow directly on pull requests and manual runs instead of a redundant wrapper
- run the integration suite on staging-targeted pull requests while avoiding fork failures
- gate deployments on successful test jobs and allow manual dev deployments from pull-request branches via workflow inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6908e4af86f08320b02e1082f5f06cc6