### PR TITLE
Add delete page endpoint and cover integration cleanup

### DIFF
--- a/conflagent.py
+++ b/conflagent.py
@@ -258,6 +258,55 @@ def api_update_page(endpoint_name: str, title: str):
     return jsonify(client.update_page(page, new_body))
 
 
+@app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["DELETE"])
+@with_config
+@document_operation(
+    "/pages/{title}",
+    "delete",
+    summary="Delete a page by title",
+    description=(
+        "Deletes a Confluence page that is a direct child of the configured root "
+        "page. All descendants of the page are also deleted."
+    ),
+    operationId="deletePageByTitle",
+    parameters=[
+        {
+            "name": "title",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+        }
+    ],
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "Page deleted successfully",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                    }
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {
+            "description": "Not Found: Page not found or not a child of root",
+        },
+    },
+)
+def api_delete_page(endpoint_name: str, title: str):
+    check_auth()
+
+    client = _get_client()
+    page = client.get_page_by_path(title)
+    if not page:
+        abort(404, description="Page not found")
+
+    return jsonify(client.delete_page(page))
+
+
 @app.route("/endpoint/<endpoint_name>/pages/rename", methods=["POST"])
 @with_config
 @document_operation(

--- a/conflagent_core/confluence.py
+++ b/conflagent_core/confluence.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import requests
 from flask import abort
@@ -41,9 +41,16 @@ class ConfluenceClient:
             "Content-Type": "application/json",
         }
 
-    def _request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        expected_status: Sequence[int] = (200, 201),
+        **kwargs: Any,
+    ) -> requests.Response:
         response = requests.request(method, url, headers=self.build_headers(), **kwargs)
-        if response.status_code != 200:
+        if response.status_code not in expected_status:
             abort(response.status_code, response.text)
         return response
 
@@ -169,4 +176,9 @@ class ConfluenceClient:
         url = f"{self.base_url}/rest/api/content/{page['id']}"
         self._request("put", url, json=payload)
         return {"message": "Page renamed", "version": version}
+
+    def delete_page(self, page: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/content/{page['id']}"
+        self._request("delete", url, expected_status=(204, 200))
+        return {"message": "Page deleted"}
 

--- a/tests/integration/test_dev_integration.py
+++ b/tests/integration/test_dev_integration.py
@@ -21,8 +21,6 @@ SANDBOX_UPDATED_BODY = (
     "# Sandbox Test Page (Updated)\nThis page has been updated successfully."
 )
 SANDBOX_RENAMED_TITLE = f"{SANDBOX_TITLE}_RENAMED"
-CLEANED_PREFIX = "CLEANED_SANDBOX_"
-PLACEHOLDER_BODY = "# Test Cleanup Placeholder\nThis page was archived by the test suite."
 
 
 @pytest.fixture(scope="session")
@@ -119,13 +117,20 @@ def _rename_page(config: Dict[str, str], old_title: str, new_title: str) -> Dict
     return payload
 
 
+def _delete_page(config: Dict[str, str], title: str) -> Dict[str, str]:
+    encoded_title = quote(title, safe="")
+    response = _json_request(config, "DELETE", f"/pages/{encoded_title}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "message" in payload
+    return payload
+
+
 def _cleanup_existing_sandbox_pages(config: Dict[str, str], titles: Iterable[str]) -> None:
-    for index, title in enumerate(titles):
+    for title in titles:
         if not title.startswith(SANDBOX_PREFIX):
             continue
-        cleanup_title = f"{CLEANED_PREFIX}{int(time.time())}_{index}"
-        _rename_page(config, title, cleanup_title)
-        _update_page(config, cleanup_title, PLACEHOLDER_BODY)
+        _delete_page(config, title)
 
 
 def _ensure_no_sandbox_titles(titles: Iterable[str]) -> None:
@@ -203,7 +208,7 @@ def test_openapi_schema_includes_endpoint_server(dev_config: Dict[str, str]):
 def test_conflagent_operator_sandbox_cycle(dev_config: Dict[str, str]):
     """Exercise the full sandbox lifecycle of the Conflagent operator."""
 
-    # Step 0 — Pre-cleanup: rename/archive any lingering sandbox pages.
+    # Step 0 — Pre-cleanup: delete any lingering sandbox pages.
     existing_titles = _list_pages(dev_config)
     _cleanup_existing_sandbox_pages(dev_config, existing_titles)
     _ensure_no_sandbox_titles(_list_pages(dev_config))
@@ -217,10 +222,9 @@ def test_conflagent_operator_sandbox_cycle(dev_config: Dict[str, str]):
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
-    # Steps 2-6 execute in a try/finally to guarantee cleanup.
+    # Steps 2-7 execute in a try/finally to guarantee cleanup.
     created_title = SANDBOX_TITLE
     renamed_title = SANDBOX_RENAMED_TITLE
-    final_title = f"{CLEANED_PREFIX}{int(time.time())}_final"
 
     try:
         # Step 2 — Create a Page
@@ -243,15 +247,16 @@ def test_conflagent_operator_sandbox_cycle(dev_config: Dict[str, str]):
         assert renamed_title in titles_after_rename
         assert created_title not in titles_after_rename
 
+        # Step 6 — Delete the Page
+        delete_result = _delete_page(dev_config, renamed_title)
+        assert "deleted" in delete_result["message"].lower()
+
     finally:
-        # Step 6 — Post-cleanup
-        # TODO: replace with a dedicated delete endpoint when available.
+        # Step 7 — Post-cleanup
         current_titles = _list_pages(dev_config)
-        if renamed_title in current_titles:
-            _rename_page(dev_config, renamed_title, final_title)
-            _update_page(dev_config, final_title, PLACEHOLDER_BODY)
-        elif created_title in current_titles:
-            _rename_page(dev_config, created_title, final_title)
-            _update_page(dev_config, final_title, PLACEHOLDER_BODY)
+        for lingering in (renamed_title, created_title):
+            if lingering in current_titles:
+                delete_result = _delete_page(dev_config, lingering)
+                assert "deleted" in delete_result["message"].lower()
 
     _ensure_no_sandbox_titles(_list_pages(dev_config))

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -93,6 +93,34 @@ def test_update_page_missing(mock_load_config, mock_client_cls, client):
     )
     assert response.status_code == 404
 
+
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_delete_page(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = {"id": "222", "title": "some/page"}
+    mock_client.delete_page.return_value = {"message": "Page deleted"}
+    response = client.delete(
+        f"/endpoint/{endpoint}/pages/some/page",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Page deleted"}
+    mock_client.delete_page.assert_called_once_with({"id": "222", "title": "some/page"})
+
+
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_delete_page_missing(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = None
+    response = client.delete(
+        f"/endpoint/{endpoint}/pages/missing",
+        headers=headers,
+    )
+    assert response.status_code == 404
+
+
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_rename_page(mock_load_config, mock_client_cls, client):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -216,3 +216,29 @@ def test_rename_page_failure():
 
         assert getattr(exc.value, "code", None) == 500
 
+
+def test_delete_page_success():
+    with app.test_request_context():
+        client = make_client()
+        with patch.object(ConfluenceClient, "_request") as mock_request:
+            result = client.delete_page({"id": "123"})
+
+        mock_request.assert_called_once_with(
+            "delete",
+            "http://example.com/rest/api/content/123",
+            expected_status=(204, 200),
+        )
+        assert result == {"message": "Page deleted"}
+
+
+def test_delete_page_failure():
+    with app.test_request_context():
+        client = make_client()
+        failure = HTTPException("bad")
+        failure.code = 500
+        with patch.object(ConfluenceClient, "_request", side_effect=failure):
+            with pytest.raises(HTTPException) as exc:
+                client.delete_page({"id": "999"})
+
+        assert getattr(exc.value, "code", None) == 500
+


### PR DESCRIPTION
## Summary
- add a DELETE /pages/{title} endpoint with OpenAPI metadata
- update the Confluence client to support delete operations and provide a helper
- extend integration and unit tests to exercise the delete action during lifecycle cleanup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690911311e1883209a2f23f789e85d8b