### PR TITLE
Add workflow to rebase branches onto main

### DIFF
--- a/.github/workflows/rebase-on-main.yml
+++ b/.github/workflows/rebase-on-main.yml
@@ -1,0 +1,35 @@
+name: Rebase on Main
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  rebase-on-main:
+    name: Rebase current branch onto main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out triggering branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Fetch latest main
+        run: git fetch origin main
+
+      - name: Rebase onto origin/main
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git rebase origin/main
+
+      - name: Force push rebased branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git push --force-with-lease origin "HEAD:${BRANCH}"


### PR DESCRIPTION
## Summary
- add a workflow_dispatch job that rebases the triggering branch onto origin/main
- push the rebased branch back to the repository using --force-with-lease

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69092703cdd08320960d0846eeb5326f