### PR TITLE
feat: Add delete page endpoint

### DIFF
--- a/conflagent.py
+++ b/conflagent.py
@@ -258,6 +258,57 @@ def api_update_page(endpoint_name: str, title: str):
     return jsonify(client.update_page(page, new_body))
 
 
+@app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["DELETE"])
+@with_config
+@document_operation(
+    "/pages/{title}",
+    "delete",
+    summary="Delete a page by title",
+    description=(
+        "Deletes a Confluence page identified by title. Only pages under the "
+        "configured root are deletable."
+    ),
+    operationId="deletePageByTitle",
+    parameters=[
+        {
+            "name": "title",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+        }
+    ],
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "Page deleted successfully",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"},
+                        },
+                    }
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {
+            "description": "Not Found: Page not found or not a child of root"
+        },
+    },
+)
+def api_delete_page(endpoint_name: str, title: str):
+    check_auth()
+
+    client = _get_client()
+    page = client.get_page_by_path(title)
+    if not page:
+        abort(404, description="Page not found")
+
+    return jsonify(client.delete_page(page))
+
+
 @app.route("/endpoint/<endpoint_name>/pages/rename", methods=["POST"])
 @with_config
 @document_operation(

--- a/conflagent_core/confluence.py
+++ b/conflagent_core/confluence.py
@@ -170,3 +170,10 @@ class ConfluenceClient:
         self._request("put", url, json=payload)
         return {"message": "Page renamed", "version": version}
 
+    def delete_page(self, page: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/content/{page['id']}"
+        response = requests.request("delete", url, headers=self.build_headers())
+        if response.status_code not in {200, 202, 204}:
+            abort(response.status_code, response.text)
+        return {"message": "Page deleted"}
+

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -95,6 +95,30 @@ def test_update_page_missing(mock_load_config, mock_client_cls, client):
 
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_delete_page(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = {"id": "999", "title": "some/page"}
+    mock_client.delete_page.return_value = {"message": "Page deleted"}
+    response = client.delete(
+        f"/endpoint/{endpoint}/pages/some/page",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Page deleted"}
+
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+def test_delete_page_missing(mock_load_config, mock_client_cls, client):
+    mock_client = mock_client_cls.return_value
+    mock_client.get_page_by_path.return_value = None
+    response = client.delete(
+        f"/endpoint/{endpoint}/pages/missing",
+        headers=headers,
+    )
+    assert response.status_code == 404
+
+@patch("conflagent.ConfluenceClient")
+@patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_rename_page(mock_load_config, mock_client_cls, client):
     mock_client = mock_client_cls.return_value
     mock_client.get_page_by_path.return_value = {"id": "111", "title": "old/page"}


### PR DESCRIPTION
## Summary
- add a DELETE `/pages/{title}` route that delegates to a new Confluence client helper
- extend the integration sandbox helpers to delete leftover pages and cover delete flow
- add API endpoint unit tests for the delete success and failure paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6909aff70ce083209bb8cd89e5c94f62