### PR TITLE
feat: Add structured response envelopes to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ GPT tool calls must include this to access or modify Confluence content. The sec
 | GET    | `/endpoint/<endpoint>/openapi.json`         | Dynamic OpenAPI schema for GPT tooling                                           | ❌ No           |
 | GET    | `/endpoint/<endpoint>/health`               | Health check                                                                     | ❌ No           |
 
+## 📦 Standard Response Envelope
+
+Every REST call now returns a structured envelope that is easy for GPT agents and other clients to parse consistently:
+
+```
+{
+  "success": true,
+  "code": "OK",
+  "message": "Operation completed successfully.",
+  "data": { /* endpoint-specific payload */ },
+  "timestamp": "2025-11-04T09:20:31Z"
+}
+```
+
+Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `success` | Boolean indicating whether the operation succeeded. |
+| `code` | Machine-readable status string (`OK`, `INVALID_INPUT`, `NOT_FOUND`, `VERSION_CONFLICT`, `UNAUTHORIZED`, `INTERNAL_ERROR`). |
+| `message` | Human-oriented summary of the outcome. |
+| `data` | Operation-specific payload on success; `null` on failures. |
+| `timestamp` | Server-side ISO 8601 timestamp for the response. |
+
+Error responses return `success: false`, populate `code` with one of the values listed above, include a descriptive `message`, and set `data` to `null`.
+
 ## 🤖 GPT Integration Guide
 
 To integrate this API with a Custom GPT:

--- a/conflagent_core/openapi.py
+++ b/conflagent_core/openapi.py
@@ -72,7 +72,7 @@ def _collect_documented_paths(flask_app: Flask) -> Dict[str, Dict[str, Any]]:
 def _build_spec(flask_app: Flask) -> APISpec:
     spec = APISpec(
         title="Conflagent API",
-        version="2.2.0",
+        version="2.3.0",
         openapi_version="3.1.0",
         info={"description": _API_DESCRIPTION},
     )

--- a/conflagent_core/response.py
+++ b/conflagent_core/response.py
@@ -1,0 +1,62 @@
+"""Utilities for producing consistent API response envelopes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from flask import jsonify
+
+
+@dataclass(frozen=True)
+class ResponseEnvelope:
+    """Container describing the standard API response envelope."""
+
+    success: bool
+    code: str
+    message: str
+    data: Optional[Any]
+    timestamp: str
+
+    @classmethod
+    def build(
+        cls,
+        success: bool,
+        code: str,
+        message: str,
+        data: Optional[Any] = None,
+    ) -> "ResponseEnvelope":
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        return cls(success=success, code=code, message=message, data=data, timestamp=timestamp)
+
+    def to_flask_response(self, status_code: int) -> Tuple[Any, int]:
+        payload: Dict[str, Any] = {
+            "success": self.success,
+            "code": self.code,
+            "message": self.message,
+            "data": self.data,
+            "timestamp": self.timestamp,
+        }
+        return jsonify(payload), status_code
+
+
+def success_response(
+    message: str,
+    data: Optional[Any] = None,
+    *,
+    code: str = "OK",
+    status_code: int = 200,
+) -> Tuple[Any, int]:
+    envelope = ResponseEnvelope.build(True, code, message, data)
+    return envelope.to_flask_response(status_code)
+
+
+def error_response(
+    code: str,
+    message: str,
+    *,
+    status_code: int,
+) -> Tuple[Any, int]:
+    envelope = ResponseEnvelope.build(False, code, message, None)
+    return envelope.to_flask_response(status_code)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -30,7 +30,11 @@ def test_list_pages(mock_load_config, mock_client_cls, client):
     mock_client.list_pages.return_value = ["Path1/PageA", "Path2/PageB"]
     response = client.get(f"/endpoint/{endpoint}/pages", headers=headers)
     assert response.status_code == 200
-    assert response.get_json() == ["Path1/PageA", "Path2/PageB"]
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["code"] == "OK"
+    assert payload["data"] == ["Path1/PageA", "Path2/PageB"]
+    assert "timestamp" in payload
 
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
@@ -40,7 +44,9 @@ def test_read_page(mock_load_config, mock_client_cls, client):
     mock_client.get_page_body.return_value = "Test content"
     response = client.get(f"/endpoint/{endpoint}/pages/some/page", headers=headers)
     assert response.status_code == 200
-    assert response.get_json() == {"title": "some/page", "body": "Test content"}
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"] == {"title": "some/page", "body": "Test content"}
 
 
 @patch("conflagent.ConfluenceClient")
@@ -50,15 +56,20 @@ def test_read_page_missing(mock_load_config, mock_client_cls, client):
     mock_client.get_page_by_path.return_value = None
     response = client.get(f"/endpoint/{endpoint}/pages/missing", headers=headers)
     assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "NOT_FOUND"
 
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_create_page(mock_load_config, mock_client_cls, client):
     mock_client = mock_client_cls.return_value
-    mock_client.create_or_update_page.return_value = {"message": "Page created", "id": "456"}
+    mock_client.create_or_update_page.return_value = {"id": "456", "version": 1}
     response = client.post(f"/endpoint/{endpoint}/pages", json={"title": "some/page", "body": "new content"}, headers=headers)
     assert response.status_code == 200
-    assert response.get_json() == {"message": "Page created", "id": "456"}
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"] == {"id": "456", "version": 1}
 
 
 @patch("conflagent_core.config.load_config", return_value=mock_config)
@@ -69,16 +80,22 @@ def test_create_page_requires_title(mock_load_config, client):
         headers=headers,
     )
     assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "INVALID_INPUT"
+    assert "Title is required" in payload["message"]
 
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_update_page(mock_load_config, mock_client_cls, client):
     mock_client = mock_client_cls.return_value
     mock_client.get_page_by_path.return_value = {"id": "789", "title": "some/page"}
-    mock_client.update_page.return_value = {"message": "Page updated", "version": 2}
+    mock_client.update_page.return_value = {"version": 2}
     response = client.put(f"/endpoint/{endpoint}/pages/some/page", json={"body": "updated content"}, headers=headers)
     assert response.status_code == 200
-    assert response.get_json() == {"message": "Page updated", "version": 2}
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"] == {"version": 2}
 
 
 @patch("conflagent.ConfluenceClient")
@@ -92,19 +109,24 @@ def test_update_page_missing(mock_load_config, mock_client_cls, client):
         headers=headers,
     )
     assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "NOT_FOUND"
 
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_delete_page(mock_load_config, mock_client_cls, client):
     mock_client = mock_client_cls.return_value
     mock_client.get_page_by_path.return_value = {"id": "999", "title": "some/page"}
-    mock_client.delete_page.return_value = {"message": "Page deleted"}
+    mock_client.delete_page.return_value = {"deleted_title": "some/page"}
     response = client.delete(
         f"/endpoint/{endpoint}/pages/some/page",
         headers=headers,
     )
     assert response.status_code == 200
-    assert response.get_json() == {"message": "Page deleted"}
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"] == {"deletedTitle": "some/page"}
 
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
@@ -116,16 +138,29 @@ def test_delete_page_missing(mock_load_config, mock_client_cls, client):
         headers=headers,
     )
     assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "NOT_FOUND"
 
 @patch("conflagent.ConfluenceClient")
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_rename_page(mock_load_config, mock_client_cls, client):
     mock_client = mock_client_cls.return_value
     mock_client.get_page_by_path.return_value = {"id": "111", "title": "old/page"}
-    mock_client.rename_page.return_value = {"message": "Page renamed", "version": 2}
+    mock_client.rename_page.return_value = {
+        "old_title": "old/page",
+        "new_title": "new/page",
+        "version": 2,
+    }
     response = client.post(f"/endpoint/{endpoint}/pages/rename", json={"old_title": "old/page", "new_title": "new/page"}, headers=headers)
     assert response.status_code == 200
-    assert response.get_json() == {"message": "Page renamed", "new_title": "new/page", "version": 2}
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"] == {
+        "oldTitle": "old/page",
+        "newTitle": "new/page",
+        "version": 2,
+    }
 
 
 @patch("conflagent_core.config.load_config", return_value=mock_config)
@@ -136,6 +171,9 @@ def test_rename_page_requires_fields(mock_load_config, client):
         headers=headers,
     )
     assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "INVALID_INPUT"
 
 
 @patch("conflagent.ConfluenceClient")
@@ -149,12 +187,17 @@ def test_rename_page_missing_source(mock_load_config, mock_client_cls, client):
         headers=headers,
     )
     assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["code"] == "NOT_FOUND"
 
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_health(mock_load_config, client):
     response = client.get(f"/endpoint/{endpoint}/health")
     assert response.status_code == 200
-    assert response.get_json()["status"] == "ok"
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"] == {"status": "ok"}
 
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_openapi_schema(mock_load_config, client):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -64,7 +64,7 @@ def test_update_page():
         with patch.object(ConfluenceClient, "_request", side_effect=[get_response, put_response]):
             result = client.update_page({"id": "999", "title": "TestPage"}, "Updated body")
 
-        assert result == {"message": "Page updated", "version": 2}
+        assert result == {"version": 2}
 
 
 def test_update_page_abort_on_failure():
@@ -169,11 +169,11 @@ def test_create_or_update_page_updates_existing():
         existing_page = {"id": "1", "title": "Page"}
         with patch.object(ConfluenceClient, "resolve_or_create_path", return_value="parent"), patch.object(
             ConfluenceClient, "get_page_by_title", return_value=existing_page
-        ), patch.object(ConfluenceClient, "update_page", return_value={"message": "Page updated"}) as mock_update:
+        ), patch.object(ConfluenceClient, "update_page", return_value={"version": 2}) as mock_update:
             result = client.create_or_update_page("Parent/Page", "body")
 
         mock_update.assert_called_once_with(existing_page, "body")
-        assert result == {"message": "Page updated"}
+        assert result == {"id": "1", "version": 2}
 
 
 def test_create_or_update_page_creates_new():
@@ -186,7 +186,7 @@ def test_create_or_update_page_creates_new():
         ), patch.object(ConfluenceClient, "_request", return_value=post_response):
             result = client.create_or_update_page("Parent/NewPage", "body")
 
-        assert result == {"message": "Page created", "id": "99"}
+        assert result == {"id": "99", "version": 1}
 
 
 def test_rename_page_success():
@@ -200,7 +200,7 @@ def test_rename_page_success():
         ):
             result = client.rename_page({"id": "1", "title": "Old"}, "New")
 
-        assert result == {"message": "Page renamed", "version": 2}
+        assert result == {"old_title": "Old", "new_title": "New", "version": 2}
 
 
 def test_rename_page_failure():

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -161,7 +161,7 @@ def test_generate_openapi_spec_includes_routes_and_server_metadata() -> None:
     spec = generate_openapi_spec("alpha", host_url, app)
 
     assert spec["info"]["title"] == "Conflagent API"
-    assert spec["info"]["version"] == "2.2.0"
+    assert spec["info"]["version"] == "2.3.0"
     assert spec["servers"] == [
         {
             "url": "https://example.test/root/endpoint/alpha",

--- a/tests/test_response_envelope.py
+++ b/tests/test_response_envelope.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from conflagent import app
+from conflagent_core.response import ResponseEnvelope, error_response, success_response
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """Convert a timestamp with trailing Z into a timezone-aware datetime."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def test_response_envelope_build_produces_iso_timestamp():
+    envelope = ResponseEnvelope.build(True, "OK", "done", data={"example": 1})
+
+    assert envelope.success is True
+    assert envelope.code == "OK"
+    assert envelope.message == "done"
+    assert envelope.data == {"example": 1}
+    parsed_timestamp = _parse_timestamp(envelope.timestamp)
+    assert parsed_timestamp.tzinfo is not None
+
+
+def test_success_response_serialises_payload():
+    with app.test_request_context():
+        response, status_code = success_response("created", {"id": 1})
+
+    assert status_code == 200
+    payload = response.get_json()
+    assert payload == {
+        "success": True,
+        "code": "OK",
+        "message": "created",
+        "data": {"id": 1},
+        "timestamp": payload["timestamp"],
+    }
+    _parse_timestamp(payload["timestamp"])
+
+
+def test_error_response_omits_data_field():
+    with app.test_request_context():
+        response, status_code = error_response("NOT_FOUND", "Missing", status_code=404)
+
+    assert status_code == 404
+    payload = response.get_json()
+    assert payload == {
+        "success": False,
+        "code": "NOT_FOUND",
+        "message": "Missing",
+        "data": None,
+        "timestamp": payload["timestamp"],
+    }
+    _parse_timestamp(payload["timestamp"])


### PR DESCRIPTION
## Summary
- wrap API endpoints in a reusable response envelope with consistent success and error handling
- adjust Confluence client helpers and OpenAPI docs to match the new payload shape
- update automated tests and documentation to cover the structured responses

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_6909b2af886c8320804097202737406d