### PR TITLE
feat: Multi-Level Page Hierarchy Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Operations limited to a pre-defined Confluence space and root page per endpoint
 - Fully compatible with Custom GPTs via OpenAPI tool definition
 - Minimal, self-contained Flask app with no external database
+- Hierarchical navigation endpoints accept **page titles** (no Confluence IDs required); Conflagent resolves IDs internally when calling the Confluence API
 
 ## 📚 Use Case
 
@@ -82,15 +83,19 @@ GPT tool calls must include this to access or modify Confluence content. The sec
 
 ## 📖 API Endpoints (summary for each `<endpoint>`)
 
-| Method | Path                                         | Description                                                                      | Auth required |
-|--------|----------------------------------------------|----------------------------------------------------------------------------------|----------------|
-| GET    | `/endpoint/<endpoint>/pages`                | List all subpages under the root                                                 | ✅ Yes          |
-| GET    | `/endpoint/<endpoint>/pages/{title}`        | Read a page by title (returned as Confluence HTML)                              | ✅ Yes          |
-| POST   | `/endpoint/<endpoint>/pages`                | Create a new page under root. Accepts Markdown, auto-converted to Confluence.   | ✅ Yes          |
-| PUT    | `/endpoint/<endpoint>/pages/{title}`        | Update a page. Submit **full** content. Accepts Markdown input.                  | ✅ Yes          |
-| POST   | `/endpoint/<endpoint>/pages/rename`         | Rename a page from one title to another                                          | ✅ Yes          |
-| GET    | `/endpoint/<endpoint>/openapi.json`         | Dynamic OpenAPI schema for GPT tooling                                           | ❌ No           |
-| GET    | `/endpoint/<endpoint>/health`               | Health check                                                                     | ❌ No           |
+| Method | Path | Description | Auth required |
+|--------|------|-------------|----------------|
+| GET    | `/endpoint/<endpoint>/pages` | List all subpages under the root | ✅ Yes |
+| GET    | `/endpoint/<endpoint>/pages/tree` | Retrieve the page hierarchy (depth-limited) | ✅ Yes |
+| GET    | `/endpoint/<endpoint>/pages/{title}` | Read a page by title (returned as Confluence HTML) | ✅ Yes |
+| GET    | `/endpoint/<endpoint>/pages/{title}/children` | List the direct children for a page (identified by title) | ✅ Yes |
+| GET    | `/endpoint/<endpoint>/pages/{title}/parent` | Retrieve parent metadata and breadcrumb path | ✅ Yes |
+| POST   | `/endpoint/<endpoint>/pages` | Create a new page under root or a specified parent title. Accepts Markdown input. | ✅ Yes |
+| POST   | `/endpoint/<endpoint>/pages/{title}/move` | Move a page beneath a new parent title (circular moves blocked) | ✅ Yes |
+| PUT    | `/endpoint/<endpoint>/pages/{title}` | Update a page. Submit **full** content. Accepts Markdown input. | ✅ Yes |
+| POST   | `/endpoint/<endpoint>/pages/rename` | Rename a page from one title to another | ✅ Yes |
+| GET    | `/endpoint/<endpoint>/openapi.json` | Dynamic OpenAPI schema for GPT tooling | ❌ No |
+| GET    | `/endpoint/<endpoint>/health` | Health check | ❌ No |
 
 ## 📦 Standard Response Envelope
 
@@ -111,7 +116,7 @@ Key fields:
 | Field | Description |
 |-------|-------------|
 | `success` | Boolean indicating whether the operation succeeded. |
-| `code` | Machine-readable status string (`OK`, `INVALID_INPUT`, `NOT_FOUND`, `VERSION_CONFLICT`, `UNAUTHORIZED`, `INTERNAL_ERROR`). |
+| `code` | Machine-readable status string (`OK`, `INVALID_INPUT`, `NOT_FOUND`, `VERSION_CONFLICT`, `INVALID_OPERATION`, `UNAUTHORIZED`, `INTERNAL_ERROR`). |
 | `message` | Human-oriented summary of the outcome. |
 | `data` | Operation-specific payload on success; `null` on failures. |
 | `timestamp` | Server-side ISO 8601 timestamp for the response. |

--- a/conflagent.py
+++ b/conflagent.py
@@ -27,6 +27,7 @@ _ERROR_CODE_BY_STATUS: Dict[int, str] = {
     403: "UNAUTHORIZED",
     404: "NOT_FOUND",
     409: "VERSION_CONFLICT",
+    422: "INVALID_OPERATION",
     500: "INTERNAL_ERROR",
 }
 
@@ -65,6 +66,18 @@ def _get_client() -> ConfluenceClient:
     return ConfluenceClient(g.config)
 
 
+def _parse_depth(raw_depth: Optional[str]) -> int:
+    if raw_depth is None:
+        return 2
+    try:
+        depth = int(raw_depth)
+    except (TypeError, ValueError):  # pragma: no cover - guarded via tests
+        abort(400, description="Depth must be an integer")
+    if depth < 0:
+        abort(400, description="Depth must be non-negative")
+    return depth
+
+
 @app.errorhandler(HTTPException)
 def _handle_http_exception(exc: HTTPException):  # pragma: no cover - behaviour asserted in tests
     message = exc.description or exc.name
@@ -75,6 +88,184 @@ def _handle_http_exception(exc: HTTPException):  # pragma: no cover - behaviour 
 @app.errorhandler(Exception)
 def _handle_unexpected_exception(exc: Exception):  # pragma: no cover - behaviour asserted in tests
     return error_response("INTERNAL_ERROR", "An unexpected error occurred.", status_code=500)
+
+
+@app.route("/endpoint/<endpoint_name>/pages/tree", methods=["GET"])
+@with_config
+@document_operation(
+    "/pages/tree",
+    "get",
+    summary="Retrieve the page hierarchy",
+    description=(
+        "Returns a nested representation of the Confluence page tree starting from the "
+        "configured root (or a specified node)."
+    ),
+    operationId="getPageTree",
+    parameters=[
+        {
+            "name": "depth",
+            "in": "query",
+            "required": False,
+            "schema": {"type": "integer", "minimum": 0},
+        },
+        {
+            "name": "startTitle",
+            "in": "query",
+            "required": False,
+            "schema": {"type": "string"},
+            "description": "Optional title to use as the root of the returned tree.",
+        },
+    ],
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "Page tree returned",
+            "content": {
+                "application/json": {
+                    "schema": _response_schema(
+                        {
+                            "type": "object",
+                            "required": ["title", "path", "children"],
+                            "properties": {
+                                "title": {"type": "string"},
+                                "path": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "children": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["title", "path", "children"],
+                                        "properties": {
+                                            "title": {"type": "string"},
+                                            "path": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                            },
+                                            "children": {
+                                                "type": "array",
+                                                "items": {"type": "object"},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    )
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+    },
+)
+def api_get_page_tree(endpoint_name: str):
+    check_auth()
+    client = _get_client()
+    depth = _parse_depth(request.args.get("depth"))
+    start_title = request.args.get("startTitle") or None
+    tree = client.get_page_tree(start_title=start_title, depth=depth)
+    return _success("Page tree retrieved.", data=tree)
+
+
+@app.route("/endpoint/<endpoint_name>/pages/<path:title>/children", methods=["GET"])
+@with_config
+@document_operation(
+    "/pages/{title}/children",
+    "get",
+    summary="List direct child pages",
+    parameters=[
+        {
+            "name": "title",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+            "description": "Title (or full path) of the page whose children will be listed.",
+        }
+    ],
+    operationId="listChildPages",
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "Child pages returned",
+            "content": {
+                "application/json": {
+                    "schema": _response_schema(
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": ["title", "path"],
+                                "properties": {
+                                    "title": {"type": "string"},
+                                    "path": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                },
+                            },
+                        }
+                    )
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {"description": "Not Found: Page does not exist"},
+    },
+)
+def api_list_children(endpoint_name: str, title: str):
+    check_auth()
+    client = _get_client()
+    children = client.get_page_children(title)
+    return _success("Child pages retrieved.", data=children)
+
+
+@app.route("/endpoint/<endpoint_name>/pages/<path:title>/parent", methods=["GET"])
+@with_config
+@document_operation(
+    "/pages/{title}/parent",
+    "get",
+    summary="Retrieve parent page metadata",
+    parameters=[
+        {
+            "name": "title",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+            "description": "Title (or full path) of the page to inspect.",
+        }
+    ],
+    operationId="getParentPage",
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "Parent metadata returned",
+            "content": {
+                "application/json": {
+                    "schema": _response_schema(
+                        {
+                            "type": "object",
+                            "properties": {
+                                "title": {"type": "string"},
+                                "path": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                            },
+                        }
+                    )
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {"description": "Not Found: Page does not exist"},
+    },
+)
+def api_get_parent(endpoint_name: str, title: str):
+    check_auth()
+    client = _get_client()
+    parent = client.get_page_parent(title)
+    return _success("Parent metadata retrieved.", data=parent)
 
 
 @app.route("/endpoint/<endpoint_name>/pages", methods=["GET"])
@@ -184,11 +375,11 @@ def api_read_page(endpoint_name: str, title: str):
 @document_operation(
     "/pages",
     "post",
-    summary="Create a new child page under root",
+    summary="Create a new page within the hierarchy",
     description=(
-        "Creates a new Confluence page as a direct child of the configured root "
-        "page. Title must be unique under the root. Body may contain Markdown — "
-        "it will be converted to Confluence storage format automatically."
+        "Creates a new Confluence page beneath the configured root or a specified parent. "
+        "Title must be unique amongst siblings. Body may contain Markdown — it will be "
+        "converted to Confluence storage format automatically."
     ),
     operationId="createPage",
     security=BEARER_SECURITY_REQUIREMENT,
@@ -208,6 +399,10 @@ def api_read_page(endpoint_name: str, title: str):
                                 "Confluence HTML format."
                             ),
                         },
+                        "parentTitle": {
+                            "type": "string",
+                            "description": "Optional parent page title. Defaults to the configured root when omitted.",
+                        },
                     },
                 }
             }
@@ -221,12 +416,12 @@ def api_read_page(endpoint_name: str, title: str):
                     "schema": _response_schema(
                         {
                             "type": "object",
-                            "required": ["id", "version"],
-                            "properties": {
-                                "id": {"type": "string"},
-                                "version": {"type": "integer"},
-                            },
-                        }
+                    "required": ["title", "version"],
+                    "properties": {
+                        "title": {"type": "string"},
+                        "version": {"type": "integer"},
+                    },
+                }
                     )
                 }
             },
@@ -242,13 +437,87 @@ def api_create_page(endpoint_name: str):
     data = request.get_json(force=True)
     title = data.get("title")
     body = data.get("body", "")
+    parent_title = data.get("parentTitle")
     if not title:
         abort(400, description="Title is required")
 
     client = _get_client()
-    result = client.create_or_update_page(title, body)
-    data = {"id": result["id"], "version": result["version"]}
+    result = client.create_page(title, body, parent_title)
+    data = {"title": result["title"], "version": result["version"]}
     return _success("Page created.", data=data)
+
+
+@app.route("/endpoint/<endpoint_name>/pages/<path:title>/move", methods=["POST"])
+@with_config
+@document_operation(
+    "/pages/{title}/move",
+    "post",
+    summary="Move a page under a new parent",
+    description="Re-parents an existing page to a new ancestor within the same space.",
+    operationId="movePage",
+    parameters=[
+        {
+            "name": "title",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+            "description": "Title (or full path) of the page to move.",
+        }
+    ],
+    requestBody={
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["newParentTitle"],
+                    "properties": {
+                        "newParentTitle": {"type": "string"},
+                    },
+                }
+            }
+        },
+    },
+    security=BEARER_SECURITY_REQUIREMENT,
+    responses={
+        "200": {
+            "description": "Page moved successfully",
+            "content": {
+                "application/json": {
+                    "schema": _response_schema(
+                        {
+                            "type": "object",
+                            "required": ["title", "oldParentTitle", "newParentTitle"],
+                            "properties": {
+                                "title": {"type": "string"},
+                                "oldParentTitle": {"type": ["string", "null"]},
+                                "newParentTitle": {"type": "string"},
+                            },
+                        }
+                    )
+                }
+            },
+        },
+        "403": {"description": "Forbidden: Invalid token"},
+        "404": {"description": "Not Found: Page or new parent missing"},
+        "422": {"description": "Invalid Operation: Circular hierarchy"},
+    },
+)
+def api_move_page(endpoint_name: str, title: str):
+    check_auth()
+    data = request.get_json(force=True)
+    new_parent_title = data.get("newParentTitle")
+    if not new_parent_title:
+        abort(400, description="newParentTitle is required")
+
+    client = _get_client()
+    result = client.move_page(title, new_parent_title)
+    payload = {
+        "title": result["title"],
+        "oldParentTitle": result["old_parent_title"],
+        "newParentTitle": result["new_parent_title"],
+    }
+    return _success("Page moved.", data=payload)
 
 
 @app.route("/endpoint/<endpoint_name>/pages/<path:title>", methods=["PUT"])

--- a/conflagent.py
+++ b/conflagent.py
@@ -416,12 +416,13 @@ def api_read_page(endpoint_name: str, title: str):
                     "schema": _response_schema(
                         {
                             "type": "object",
-                    "required": ["title", "version"],
-                    "properties": {
-                        "title": {"type": "string"},
-                        "version": {"type": "integer"},
-                    },
-                }
+                            "required": ["id", "title", "version"],
+                            "properties": {
+                                "id": {"type": "string"},
+                                "title": {"type": "string"},
+                                "version": {"type": "integer"},
+                            },
+                        }
                     )
                 }
             },
@@ -443,7 +444,7 @@ def api_create_page(endpoint_name: str):
 
     client = _get_client()
     result = client.create_page(title, body, parent_title)
-    data = {"title": result["title"], "version": result["version"]}
+    data = {"id": result["id"], "title": result["title"], "version": result["version"]}
     return _success("Page created.", data=data)
 
 

--- a/conflagent_core/confluence.py
+++ b/conflagent_core/confluence.py
@@ -47,11 +47,94 @@ class ConfluenceClient:
             abort(response.status_code, response.text)
         return response
 
+    def _search_page_by_title(self, title: str, *, expand: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        expansions: List[str] = []
+        if expand:
+            expansions.extend([part for part in expand.split(",") if part])
+        if "ancestors" not in expansions:
+            expansions.append("ancestors")
+
+        params: Dict[str, Any] = {"spaceKey": self.space_key, "title": title}
+        if expansions:
+            params["expand"] = ",".join(expansions)
+
+        url = f"{self.base_url}/rest/api/content"
+        response = self._request("get", url, params=params)
+        results = response.json().get("results", [])
+        if not results:
+            return None
+        return results[0]
+
+    def _ensure_page_by_title(self, title: str, *, expand: Optional[str] = None) -> Dict[str, Any]:
+        page = self._search_page_by_title(title, expand=expand)
+        if not page:
+            abort(404, description=f"Page titled '{title}' not found")
+        return page
+
+    def _fetch_children(self, page_id: str) -> List[Dict[str, str]]:
+        url = f"{self.base_url}/rest/api/content/{page_id}/child/page"
+        response = self._request("get", url)
+        return [
+            {"id": page["id"], "title": page["title"]}
+            for page in response.json().get("results", [])
+        ]
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
     def list_pages(self) -> List[str]:
         return self._list_pages_recursive(self.root_page_id)
+
+    def _get_page(self, page_id: str, *, expand: Optional[str] = None) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/content/{page_id}"
+        params: Dict[str, Any] = {}
+        if expand:
+            params["expand"] = expand
+        response = self._request("get", url, params=params)
+        return response.json()
+
+    def get_page_children(self, page_title: str) -> List[Dict[str, Any]]:
+        page = self._ensure_page_by_title(page_title)
+        path = [ancestor["title"] for ancestor in page.get("ancestors", [])] + [page["title"]]
+        children = self._fetch_children(page["id"])
+        return [
+            {"title": child["title"], "path": path + [child["title"]]}
+            for child in children
+        ]
+
+    def get_page_parent(self, page_title: str) -> Optional[Dict[str, Any]]:
+        page = self._ensure_page_by_title(page_title)
+        ancestors = page.get("ancestors", [])
+        if not ancestors:
+            return None
+        parent = ancestors[-1]
+        path = [ancestor["title"] for ancestor in ancestors] + [page["title"]]
+        return {"title": parent["title"], "path": path}
+
+    def get_page_tree(self, start_title: Optional[str] = None, depth: int = 2) -> Dict[str, Any]:
+        if start_title:
+            start_page = self._ensure_page_by_title(start_title)
+        else:
+            start_page = self._get_page(self.root_page_id, expand="ancestors")
+
+        path = [ancestor["title"] for ancestor in start_page.get("ancestors", [])] + [
+            start_page["title"]
+        ]
+        return self._build_tree_node(start_page["id"], start_page["title"], depth, path)
+
+    def _build_tree_node(self, page_id: str, title: str, depth: int, path: List[str]) -> Dict[str, Any]:
+        node = {"title": title, "path": path, "children": []}
+        if depth <= 0:
+            return node
+
+        children = self._fetch_children(page_id)
+        node["children"] = [
+            self._build_tree_node(
+                child["id"], child["title"], depth - 1, path + [child["title"]]
+            )
+            for child in children
+        ]
+        return node
 
     def _list_pages_recursive(self, parent_id: str, prefix: str = "") -> List[str]:
         url = f"{self.base_url}/rest/api/content/{parent_id}/child/page"
@@ -144,6 +227,60 @@ class ConfluenceClient:
         return {
             "id": response_json["id"],
             "version": version_number,
+        }
+
+    def create_page(self, title: str, body: str, parent_title: Optional[str]) -> Dict[str, Any]:
+        if parent_title:
+            parent_page = self._ensure_page_by_title(parent_title)
+            ancestor_id = parent_page["id"]
+        else:
+            ancestor_id = self.root_page_id
+        payload = {
+            "type": "page",
+            "title": title,
+            "ancestors": [{"id": ancestor_id}],
+            "space": {"key": self.space_key},
+            "body": {"storage": {"value": body, "representation": "storage"}},
+        }
+        url = f"{self.base_url}/rest/api/content"
+        response = self._request("post", url, json=payload)
+        response_json = response.json()
+        version_info = response_json.get("version", {})
+        version_number = version_info.get("number", 1)
+        return {"title": title, "version": version_number}
+
+    def move_page(self, page_title: str, new_parent_title: str) -> Dict[str, Any]:
+        page = self._ensure_page_by_title(page_title, expand="version")
+        page_id = page["id"]
+        detailed_page = self._get_page(page_id, expand="ancestors,version")
+
+        ancestors = detailed_page.get("ancestors", [])
+        old_parent_title: Optional[str] = None
+        if ancestors:
+            old_parent_title = ancestors[-1]["title"]
+
+        new_parent = self._ensure_page_by_title(new_parent_title)
+        new_parent_id = new_parent["id"]
+        new_parent_details = self._get_page(new_parent_id, expand="ancestors")
+        new_parent_ancestors = [ancestor["id"] for ancestor in new_parent_details.get("ancestors", [])]
+        ancestry_chain = new_parent_ancestors + [new_parent_id]
+        if page_id in ancestry_chain:
+            abort(422, description="Cannot move page into its own subtree")
+
+        version_number = detailed_page["version"]["number"] + 1
+        payload = {
+            "id": page_id,
+            "type": "page",
+            "title": detailed_page["title"],
+            "version": {"number": version_number},
+            "ancestors": [{"id": new_parent_id}],
+        }
+        url = f"{self.base_url}/rest/api/content/{page_id}"
+        self._request("put", url, json=payload)
+        return {
+            "title": detailed_page["title"],
+            "old_parent_title": old_parent_title,
+            "new_parent_title": new_parent_details["title"],
         }
 
     def update_page(self, page: Dict[str, Any], new_body: str) -> Dict[str, Any]:

--- a/conflagent_core/confluence.py
+++ b/conflagent_core/confluence.py
@@ -299,6 +299,9 @@ class ConfluenceClient:
         page_id = page["id"]
         detailed_page = self._get_page(page_id, expand="ancestors,version")
 
+        if not self._is_descendant_of_root(detailed_page):
+            abort(404, description="Page not found")
+
         ancestors = detailed_page.get("ancestors", [])
         old_parent_title: Optional[str] = None
         if ancestors:
@@ -307,6 +310,9 @@ class ConfluenceClient:
         new_parent = self._ensure_page_by_title(new_parent_title)
         new_parent_id = new_parent["id"]
         new_parent_details = self._get_page(new_parent_id, expand="ancestors")
+
+        if not self._is_descendant_of_root(new_parent_details):
+            abort(404, description="New parent not found")
         new_parent_ancestors = [ancestor["id"] for ancestor in new_parent_details.get("ancestors", [])]
         ancestry_chain = new_parent_ancestors + [new_parent_id]
         if page_id in ancestry_chain:

--- a/conflagent_core/confluence.py
+++ b/conflagent_core/confluence.py
@@ -245,9 +245,10 @@ class ConfluenceClient:
         url = f"{self.base_url}/rest/api/content"
         response = self._request("post", url, json=payload)
         response_json = response.json()
+        page_id = response_json.get("id")
         version_info = response_json.get("version", {})
         version_number = version_info.get("number", 1)
-        return {"title": title, "version": version_number}
+        return {"id": page_id, "title": title, "version": version_number}
 
     def move_page(self, page_title: str, new_parent_title: str) -> Dict[str, Any]:
         page = self._ensure_page_by_title(page_title, expand="version")

--- a/conflagent_core/openapi.py
+++ b/conflagent_core/openapi.py
@@ -11,8 +11,8 @@ from flask import Flask, abort
 _API_DESCRIPTION = (
     "REST API bridge between Custom GPTs and a sandboxed Confluence root page. "
     "All requests must be authenticated using a Bearer token (Authorization: Bearer <token>). "
-    "API enables programmatic listing, reading, creation, updating, and renaming of Confluence pages "
-    "under a pre-defined root page."
+    "API enables programmatic listing, reading, creation, updating, moving, and renaming of Confluence pages "
+    "under a pre-defined root page, including traversal of hierarchical relationships."
 )
 
 BEARER_SECURITY_REQUIREMENT = [{"BearerAuth": []}]
@@ -72,7 +72,7 @@ def _collect_documented_paths(flask_app: Flask) -> Dict[str, Dict[str, Any]]:
 def _build_spec(flask_app: Flask) -> APISpec:
     spec = APISpec(
         title="Conflagent API",
-        version="2.3.0",
+        version="2.4.0",
         openapi_version="3.1.0",
         info={"description": _API_DESCRIPTION},
     )

--- a/tests/integration/test_dev_integration.py
+++ b/tests/integration/test_dev_integration.py
@@ -191,9 +191,14 @@ def _remove_titles(config: Dict[str, str], *titles: str) -> None:
     for title in titles:
         if not title:
             continue
-        current_titles = set(_list_pages(config))
-        if title in current_titles:
-            _delete_page(config, title)
+        current_titles = _list_pages(config)
+        matching_paths = [
+            path
+            for path in current_titles
+            if path == title or path.endswith(f"/{title}")
+        ]
+        for path in matching_paths:
+            _delete_page(config, path)
 
 
 def _encode_title(title: str) -> str:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -67,7 +67,7 @@ def test_read_page_missing(mock_load_config, mock_client_cls, client):
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_create_page(mock_load_config, mock_client_cls, client):
     mock_client = mock_client_cls.return_value
-    mock_client.create_page.return_value = {"title": "some/page", "version": 1}
+    mock_client.create_page.return_value = {"id": "123", "title": "some/page", "version": 1}
     response = client.post(
         f"/endpoint/{endpoint}/pages",
         json={"title": "some/page", "body": "new content", "parentTitle": "Root"},
@@ -76,7 +76,7 @@ def test_create_page(mock_load_config, mock_client_cls, client):
     assert response.status_code == 200
     payload = response.get_json()
     assert payload["success"] is True
-    assert payload["data"] == {"title": "some/page", "version": 1}
+    assert payload["data"] == {"id": "123", "title": "some/page", "version": 1}
     mock_client.create_page.assert_called_once_with("some/page", "new content", "Root")
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -152,6 +152,43 @@ def test_get_page_by_path_missing():
         assert page is None
 
 
+def test_get_page_by_path_single_title_descendant():
+    with app.test_request_context():
+        client = make_client()
+        page_payload = {
+            "id": "123",
+            "title": "Anywhere",
+            "ancestors": [{"id": mock_config["root_page_id"]}],
+        }
+        with patch.object(
+            ConfluenceClient,
+            "_search_page_by_title",
+            return_value=page_payload,
+        ) as mock_search:
+            page = client.get_page_by_path("Anywhere")
+
+        mock_search.assert_called_once_with("Anywhere", expand="ancestors")
+        assert page == page_payload
+
+
+def test_get_page_by_path_single_title_outside_root():
+    with app.test_request_context():
+        client = make_client()
+        page_payload = {
+            "id": "123",
+            "title": "OtherSpace",
+            "ancestors": [{"id": "not-root"}],
+        }
+        with patch.object(
+            ConfluenceClient,
+            "_search_page_by_title",
+            return_value=page_payload,
+        ):
+            page = client.get_page_by_path("OtherSpace")
+
+        assert page is None
+
+
 def test_get_page_body():
     with app.test_request_context():
         client = make_client()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from werkzeug.exceptions import HTTPException
@@ -187,6 +187,218 @@ def test_create_or_update_page_creates_new():
             result = client.create_or_update_page("Parent/NewPage", "body")
 
         assert result == {"id": "99", "version": 1}
+
+
+def test_create_page_defaults_to_root_parent():
+    with app.test_request_context():
+        client = make_client()
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "42", "version": {"number": 3}}
+        with patch.object(ConfluenceClient, "_request", return_value=post_response) as mock_request:
+            result = client.create_page("Title", "body", None)
+
+        assert result == {"title": "Title", "version": 3}
+        called_args, called_kwargs = mock_request.call_args
+        assert called_args[0] == "post"
+        assert "rest/api/content" in called_args[1]
+        assert called_kwargs["json"]["ancestors"] == [{"id": mock_config["root_page_id"]}]
+
+
+def test_create_page_with_parent_title():
+    with app.test_request_context():
+        client = make_client()
+        parent_page = {"id": "parent", "title": "Parent"}
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "77", "version": {"number": 5}}
+        with patch.object(
+            ConfluenceClient, "_ensure_page_by_title", return_value=parent_page
+        ) as mock_lookup, patch.object(ConfluenceClient, "_request", return_value=post_response) as mock_request:
+            result = client.create_page("Child", "body", "Parent")
+
+        mock_lookup.assert_called_once_with("Parent")
+        called_args, called_kwargs = mock_request.call_args
+        assert called_kwargs["json"]["ancestors"] == [{"id": "parent"}]
+        assert result == {"title": "Child", "version": 5}
+
+
+def test_get_page_children_returns_minimal_payload():
+    with app.test_request_context():
+        client = make_client()
+        page_info = {"id": "root", "title": "Parent", "ancestors": [{"title": "Root"}]}
+        child_results = [
+            {"id": "1", "title": "Child"},
+            {"id": "2", "title": "Sibling"},
+        ]
+        with patch.object(
+            ConfluenceClient, "_ensure_page_by_title", return_value=page_info
+        ) as mock_lookup, patch.object(
+            ConfluenceClient, "_fetch_children", return_value=child_results
+        ) as mock_fetch:
+            children = client.get_page_children("Parent")
+
+        mock_lookup.assert_called_once_with("Parent")
+        mock_fetch.assert_called_once_with("root")
+        assert children == [
+            {"title": "Child", "path": ["Root", "Parent", "Child"]},
+            {"title": "Sibling", "path": ["Root", "Parent", "Sibling"]},
+        ]
+
+
+def test_get_page_parent_returns_path():
+    with app.test_request_context():
+        client = make_client()
+        page_info = {
+            "id": "child",
+            "title": "Child",
+            "ancestors": [
+                {"title": "Root"},
+                {"title": "Parent"},
+            ],
+        }
+        with patch.object(ConfluenceClient, "_ensure_page_by_title", return_value=page_info) as mock_lookup:
+            parent = client.get_page_parent("Child")
+
+        mock_lookup.assert_called_once_with("Child")
+        assert parent == {
+            "title": "Parent",
+            "path": ["Root", "Parent", "Child"],
+        }
+
+
+def test_get_page_parent_root_returns_none():
+    with app.test_request_context():
+        client = make_client()
+        page_info = {"id": "root", "title": "Root", "ancestors": []}
+        with patch.object(ConfluenceClient, "_ensure_page_by_title", return_value=page_info):
+            parent = client.get_page_parent("Root")
+
+        assert parent is None
+
+
+def test_get_page_tree_respects_depth():
+    with app.test_request_context():
+        client = make_client()
+        root_page = {"id": "root", "title": "Root", "ancestors": []}
+        with patch.object(
+            ConfluenceClient, "_get_page", return_value=root_page
+        ) as mock_get_page, patch.object(
+            ConfluenceClient, "_fetch_children", return_value=[{"id": "child", "title": "Child"}]
+        ) as mock_children:
+            tree = client.get_page_tree(depth=1)
+
+        mock_get_page.assert_called_once_with(client.root_page_id, expand="ancestors")
+        mock_children.assert_called_once_with("root")
+        assert tree == {
+            "title": "Root",
+            "path": ["Root"],
+            "children": [
+                {"title": "Child", "path": ["Root", "Child"], "children": []}
+            ],
+        }
+
+
+def test_get_page_tree_zero_depth_skips_children():
+    with app.test_request_context():
+        client = make_client()
+        root_page = {"id": "root", "title": "Root", "ancestors": []}
+        with patch.object(
+            ConfluenceClient, "_get_page", return_value=root_page
+        ) as mock_get_page, patch.object(
+            ConfluenceClient, "_fetch_children"
+        ) as mock_children:
+            tree = client.get_page_tree(depth=0)
+
+        mock_get_page.assert_called_once_with(client.root_page_id, expand="ancestors")
+        mock_children.assert_not_called()
+        assert tree == {"title": "Root", "path": ["Root"], "children": []}
+
+
+def test_move_page_success():
+    with app.test_request_context():
+        client = make_client()
+        page_lookup = [
+            {"id": "child", "title": "Child", "version": {"number": 1}, "ancestors": []},
+            {"id": "parent", "title": "New", "ancestors": [{"id": "root", "title": "Root"}]},
+        ]
+        page_details = {
+            "id": "child",
+            "title": "Child",
+            "ancestors": [{"id": "old", "title": "Old"}],
+            "version": {"number": 1},
+        }
+        parent_details = {
+            "id": "parent",
+            "title": "New",
+            "ancestors": [{"id": "root", "title": "Root"}],
+        }
+        with patch.object(
+            ConfluenceClient,
+            "_ensure_page_by_title",
+            side_effect=page_lookup,
+        ) as mock_lookup, patch.object(
+            ConfluenceClient,
+            "_get_page",
+            side_effect=[page_details, parent_details],
+        ) as mock_get_page, patch.object(ConfluenceClient, "_request") as mock_request:
+            result = client.move_page("Child", "New")
+
+        assert mock_lookup.call_args_list == [
+            call("Child", expand="version"),
+            call("New"),
+        ]
+        assert mock_get_page.call_args_list == [
+            call("child", expand="ancestors,version"),
+            call("parent", expand="ancestors"),
+        ]
+        mock_request.assert_called_with(
+            "put",
+            f"{mock_config['base_url']}/rest/api/content/child",
+            json={
+                "id": "child",
+                "type": "page",
+                "title": "Child",
+                "version": {"number": 2},
+                "ancestors": [{"id": "parent"}],
+            },
+        )
+        assert result == {
+            "title": "Child",
+            "old_parent_title": "Old",
+            "new_parent_title": "New",
+        }
+
+
+def test_move_page_prevents_circular_dependency():
+    with app.test_request_context():
+        client = make_client()
+        page_lookup = [
+            {"id": "child", "title": "Child", "version": {"number": 1}, "ancestors": []},
+            {"id": "parent", "title": "Parent", "ancestors": [{"id": "child", "title": "Child"}]},
+        ]
+        page_details = {
+            "id": "child",
+            "title": "Child",
+            "ancestors": [],
+            "version": {"number": 1},
+        }
+        parent_details = {
+            "id": "parent",
+            "title": "Parent",
+            "ancestors": [{"id": "child", "title": "Child"}],
+        }
+        with patch.object(
+            ConfluenceClient,
+            "_ensure_page_by_title",
+            side_effect=page_lookup,
+        ), patch.object(
+            ConfluenceClient,
+            "_get_page",
+            side_effect=[page_details, parent_details],
+        ):
+            with pytest.raises(HTTPException) as exc:
+                client.move_page("Child", "Parent")
+
+        assert exc.value.code == 422
 
 
 def test_rename_page_success():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -197,7 +197,7 @@ def test_create_page_defaults_to_root_parent():
         with patch.object(ConfluenceClient, "_request", return_value=post_response) as mock_request:
             result = client.create_page("Title", "body", None)
 
-        assert result == {"title": "Title", "version": 3}
+        assert result == {"id": "42", "title": "Title", "version": 3}
         called_args, called_kwargs = mock_request.call_args
         assert called_args[0] == "post"
         assert "rest/api/content" in called_args[1]
@@ -218,7 +218,7 @@ def test_create_page_with_parent_title():
         mock_lookup.assert_called_once_with("Parent")
         called_args, called_kwargs = mock_request.call_args
         assert called_kwargs["json"]["ancestors"] == [{"id": "parent"}]
-        assert result == {"title": "Child", "version": 5}
+        assert result == {"id": "77", "title": "Child", "version": 5}
 
 
 def test_get_page_children_returns_minimal_payload():

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -161,7 +161,7 @@ def test_generate_openapi_spec_includes_routes_and_server_metadata() -> None:
     spec = generate_openapi_spec("alpha", host_url, app)
 
     assert spec["info"]["title"] == "Conflagent API"
-    assert spec["info"]["version"] == "2.3.0"
+    assert spec["info"]["version"] == "2.4.0"
     assert spec["servers"] == [
         {
             "url": "https://example.test/root/endpoint/alpha",


### PR DESCRIPTION
## Summary
- update the hierarchy routes and OpenAPI metadata to use page titles instead of numeric IDs and expose breadcrumb paths
- resolve Confluence IDs internally by title in the client, including tree building, child/parent lookups, creation, and move operations
- refresh tests and documentation to cover the title-based workflow and ensure circular move protection still applies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6909f690a5ec83208024dc9206bef1bf