### PR TITLE
fix: compute build metadata from checked-out commit

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -36,12 +36,11 @@ jobs:
 
       - name: Generate build.properties
         env:
-          GIT_COMMIT: ${{ github.sha }}
           GIT_REF: ${{ inputs.ref }}
           ACTOR: ${{ github.actor }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
-          COMMIT_SHA="$GIT_COMMIT"
+          COMMIT_SHA="$(git rev-parse HEAD)"
           COMMIT_TS="$(git show -s --format=%cI "$COMMIT_SHA")"
           BUILD_TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           BRANCH="$GIT_REF"


### PR DESCRIPTION
## Summary
- ensure the reusable deploy workflow derives build metadata from the checked-out revision so commit hash and timestamp are accurate

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f78edb3e883209f80d8f15af19be1)