### PR TITLE
Remove landing page API spec link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,6 @@
       <div class="landing__container">
         <h1 class="landing__hero-title">Welcome to Conflagent</h1>
         <p class="landing__hero-subtitle">Your lightweight gateway for managing Confluence hierarchies.</p>
-        <a class="landing__hero-cta" href="/openapi.json">View API Specification</a>
       </div>
     </header>
     <main class="landing__main">

--- a/tests/test_landing_page.py
+++ b/tests/test_landing_page.py
@@ -20,4 +20,5 @@ def test_landing_page_serves_static_content(client):
     html = response.data.decode('utf-8')
     assert 'landing__hero-title' in html
     assert 'Welcome to Conflagent' in html
-    assert 'View API Specification' in html
+    assert 'landing__hero-subtitle' in html
+    assert 'View API Specification' not in html


### PR DESCRIPTION
## Summary
- remove the landing page call-to-action that pointed to the non-existent API specification
- update the landing page test to expect the subtitle and ensure the removed link stays absent

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7951b52c8320a0f56355e84d96bf)