### PR TITLE
Fix integration workflow checkout for forked PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          token: ${{ secrets.PR_CHECKOUT_TOKEN != '' && secrets.PR_CHECKOUT_TOKEN || github.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,17 @@ name: Integration Tests
 
 on:
   workflow_call:
+    inputs:
+      repository:
+        description: 'Repository to checkout (owner/name). Defaults to caller repository.'
+        required: false
+        default: ''
+        type: string
+      ref:
+        description: 'Git ref to checkout. Defaults to the caller commit.'
+        required: false
+        default: ''
+        type: string
     secrets:
       CONFLAGENT_DEV_URL:
         required: true
@@ -9,6 +20,8 @@ on:
         required: true
       CONFLAGENT_DEV_TOKEN:
         required: true
+      PR_CHECKOUT_TOKEN:
+        required: false
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'
@@ -27,8 +40,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.event_name == 'workflow_call' && inputs.repository != '' && inputs.repository || github.repository }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event_name == 'workflow_call' && inputs.ref != '' && inputs.ref || github.sha }}
           token: ${{ secrets.PR_CHECKOUT_TOKEN != '' && secrets.PR_CHECKOUT_TOKEN || github.token }}
 
       - name: Set up Python

--- a/.github/workflows/pre-merge-integration.yml
+++ b/.github/workflows/pre-merge-integration.yml
@@ -46,36 +46,12 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'needs-integration-tests') ||
         (github.event.action == 'labeled' && github.event.label.name == 'needs-integration-tests')
       )
-    name: Run integration tests against dev
-    runs-on: ubuntu-latest
     needs: deploy
-
-    env:
-      CONFLAGENT_DEV_URL: ${{ secrets.CONFLAGENT_DEV_URL }}
-      CONFLAGENT_DEV_ENDPOINT: ${{ secrets.CONFLAGENT_DEV_ENDPOINT }}
-      CONFLAGENT_DEV_TOKEN: ${{ secrets.CONFLAGENT_DEV_TOKEN }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ secrets.PR_CHECKOUT_TOKEN != '' && secrets.PR_CHECKOUT_TOKEN || github.token }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run integration suite
-        run: |
-          pytest -m integration -v
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit
 
   redeploy-dev:
     if: >-


### PR DESCRIPTION
## Summary
- update the integration test workflow checkout to include the fork repository when running on pull_request_target
- fall back to a privileged token when checking out the pull request head

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f78ca4c50832086a02f6456d2f3d7)