### PR TITLE
Add markdown conversion before storing Confluence pages

### DIFF
--- a/conflagent_core/confluence.py
+++ b/conflagent_core/confluence.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional
 import requests
 from flask import abort
 
+from .content import to_confluence_storage
+
 
 class ConfluenceClient:
     """A thin wrapper around the Confluence REST API."""
@@ -259,7 +261,12 @@ class ConfluenceClient:
             "title": page_title,
             "ancestors": [{"id": parent_id}],
             "space": {"key": self.space_key},
-            "body": {"storage": {"value": body, "representation": "storage"}},
+            "body": {
+                "storage": {
+                    "value": to_confluence_storage(body),
+                    "representation": "storage",
+                }
+            },
         }
         url = f"{self.base_url}/rest/api/content"
         response = self._request("post", url, json=payload)
@@ -284,7 +291,12 @@ class ConfluenceClient:
             "title": title,
             "ancestors": [{"id": ancestor_id}],
             "space": {"key": self.space_key},
-            "body": {"storage": {"value": body, "representation": "storage"}},
+            "body": {
+                "storage": {
+                    "value": to_confluence_storage(body),
+                    "representation": "storage",
+                }
+            },
         }
         url = f"{self.base_url}/rest/api/content"
         response = self._request("post", url, json=payload)
@@ -344,7 +356,12 @@ class ConfluenceClient:
             "type": "page",
             "title": page["title"],
             "version": {"number": version},
-            "body": {"storage": {"value": new_body, "representation": "storage"}},
+            "body": {
+                "storage": {
+                    "value": to_confluence_storage(new_body),
+                    "representation": "storage",
+                }
+            },
         }
         url = f"{self.base_url}/rest/api/content/{page['id']}"
         self._request("put", url, json=payload)

--- a/conflagent_core/content.py
+++ b/conflagent_core/content.py
@@ -1,0 +1,39 @@
+"""Utilities for preparing content for Confluence storage."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+import markdown2
+
+_HTML_TAG_RE: Final[re.Pattern[str]] = re.compile(r"<\s*[a-zA-Z][^>]*>")
+
+
+def _looks_like_html(content: str) -> bool:
+    """Return ``True`` when the content already appears to be HTML."""
+
+    stripped = content.strip()
+    if not stripped:
+        return False
+    return bool(_HTML_TAG_RE.search(stripped))
+
+
+def to_confluence_storage(content: str) -> str:
+    """Convert markdown content into HTML suitable for Confluence storage.
+
+    Confluence expects the ``storage`` representation which accepts simple
+    HTML.  The application allows callers to provide markdown when creating or
+    updating a page.  This helper normalises the incoming content, only
+    applying markdown conversion when the input does not already look like
+    HTML.
+    """
+
+    if not content or not content.strip():
+        return ""
+
+    if _looks_like_html(content):
+        return content
+
+    return markdown2.markdown(content)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 requests
 pytest
 apispec
+markdown2

--- a/tests/integration/test_markdown_conversion.py
+++ b/tests/integration/test_markdown_conversion.py
@@ -1,0 +1,70 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from conflagent import app
+
+
+endpoint = "testendpoint"
+headers = {"Authorization": "Bearer testsecret"}
+
+mock_config = {
+    "gpt_shared_secret": "testsecret",
+    "root_page_id": "root",
+    "space_key": "SPACE",
+    "base_url": "http://example.com",
+    "email": "a",
+    "api_token": "b",
+}
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+@patch("conflagent.ConfluenceClient._request")
+def test_create_page_converts_markdown(mock_request, _mock_load_config, client):
+    response = MagicMock()
+    response.json.return_value = {"id": "123", "version": {"number": 1}}
+    mock_request.return_value = response
+
+    result = client.post(
+        f"/endpoint/{endpoint}/pages",
+        json={"title": "Markdown", "body": "# Heading"},
+        headers=headers,
+    )
+
+    assert result.status_code == 200
+    called_kwargs = mock_request.call_args.kwargs
+    storage_value = called_kwargs["json"]["body"]["storage"]["value"]
+    assert "<h1>Heading</h1>" in storage_value
+
+
+@patch("conflagent_core.config.load_config", return_value=mock_config)
+@patch("conflagent.ConfluenceClient.get_page_by_path", return_value={"id": "1", "title": "Markdown"})
+@patch("conflagent.ConfluenceClient._request")
+def test_update_page_converts_markdown(mock_request, _mock_get_page, _mock_load_config, client):
+    get_response = MagicMock()
+    get_response.json.return_value = {"version": {"number": 2}}
+    put_response = MagicMock()
+    put_response.json.return_value = {}
+    mock_request.side_effect = [get_response, put_response]
+
+    result = client.put(
+        f"/endpoint/{endpoint}/pages/Markdown",
+        json={"body": "*emphasis*"},
+        headers=headers,
+    )
+
+    assert result.status_code == 200
+    assert mock_request.call_count == 2
+    called_kwargs = mock_request.call_args.kwargs
+    storage_value = called_kwargs["json"]["body"]["storage"]["value"]
+    assert "<em>emphasis</em>" in storage_value

--- a/tests/integration/test_markdown_conversion.py
+++ b/tests/integration/test_markdown_conversion.py
@@ -1,3 +1,5 @@
+"""Integration-style tests to confirm markdown conversion is applied."""
+
 import os
 import sys
 from unittest.mock import MagicMock, patch

--- a/tests/test_content_converter.py
+++ b/tests/test_content_converter.py
@@ -1,3 +1,5 @@
+"""Unit tests for the markdown-to-storage converter."""
+
 from conflagent_core.content import to_confluence_storage
 
 

--- a/tests/test_content_converter.py
+++ b/tests/test_content_converter.py
@@ -1,0 +1,31 @@
+from conflagent_core.content import to_confluence_storage
+
+
+def test_converts_markdown_heading():
+    content = "# Title"
+
+    converted = to_confluence_storage(content)
+
+    assert "<h1>Title</h1>" in converted
+
+
+def test_leaves_html_untouched():
+    html = "<p>Already formatted</p>"
+
+    converted = to_confluence_storage(html)
+
+    assert converted == html
+
+
+def test_handles_plain_text():
+    content = "Simple text"
+
+    converted = to_confluence_storage(content)
+
+    assert converted.startswith("<p>")
+    assert "Simple text" in converted
+
+
+def test_empty_content_returns_empty_string():
+    assert to_confluence_storage("") == ""
+    assert to_confluence_storage("   ") == ""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -259,10 +259,12 @@ def test_create_or_update_page_creates_new():
         post_response.json.return_value = {"id": "99"}
         with patch.object(ConfluenceClient, "resolve_or_create_path", return_value="parent"), patch.object(
             ConfluenceClient, "get_page_by_title", return_value=None
-        ), patch.object(ConfluenceClient, "_request", return_value=post_response):
+        ), patch.object(ConfluenceClient, "_request", return_value=post_response) as mock_request:
             result = client.create_or_update_page("Parent/NewPage", "body")
 
         assert result == {"id": "99", "version": 1}
+        called_kwargs = mock_request.call_args.kwargs
+        assert called_kwargs["json"]["body"]["storage"]["value"].startswith("<p>")
 
 
 def test_create_page_defaults_to_root_parent():
@@ -278,6 +280,7 @@ def test_create_page_defaults_to_root_parent():
         assert called_args[0] == "post"
         assert "rest/api/content" in called_args[1]
         assert called_kwargs["json"]["ancestors"] == [{"id": mock_config["root_page_id"]}]
+        assert called_kwargs["json"]["body"]["storage"]["value"].startswith("<p>")
 
 
 def test_create_page_with_parent_title():
@@ -294,6 +297,7 @@ def test_create_page_with_parent_title():
         mock_lookup.assert_called_once_with("Parent")
         called_args, called_kwargs = mock_request.call_args
         assert called_kwargs["json"]["ancestors"] == [{"id": "parent"}]
+        assert called_kwargs["json"]["body"]["storage"]["value"].startswith("<p>")
         assert result == {"id": "77", "title": "Child", "version": 5}
 
 


### PR DESCRIPTION
## Summary
- add a markdown-to-Confluence storage converter utility using markdown2
- update the Confluence client to convert page bodies before create and update requests
- cover the conversion with new unit tests and an integration test that exercises the Flask endpoints

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7a6faa9483208838cf8bbae792ef)