### PR TITLE
Fix integration workflow triggers and ensure dev redeploy

### DIFF
--- a/.github/workflows/pre-merge-integration.yml
+++ b/.github/workflows/pre-merge-integration.yml
@@ -7,23 +7,11 @@ on:
       - opened
       - reopened
       - synchronize
-  pull_request:
-    types:
-      - labeled
-      - opened
-      - reopened
-      - synchronize
 
 jobs:
   deploy:
     if: >-
-      (
-        github.event_name == 'pull_request_target' ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        )
-      ) && (
+      (github.event_name == 'pull_request_target') && (
         contains(github.event.pull_request.labels.*.name, 'needs-integration-tests') ||
         (github.event.action == 'labeled' && github.event.label.name == 'needs-integration-tests')
       )
@@ -36,13 +24,7 @@ jobs:
 
   integration-tests:
     if: >-
-      (
-        github.event_name == 'pull_request_target' ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        )
-      ) && (
+      (github.event_name == 'pull_request_target') && (
         contains(github.event.pull_request.labels.*.name, 'needs-integration-tests') ||
         (github.event.action == 'labeled' && github.event.label.name == 'needs-integration-tests')
       )
@@ -79,13 +61,7 @@ jobs:
 
   redeploy-dev:
     if: >-
-      (
-        github.event_name == 'pull_request_target' ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        )
-      ) && (
+      always() && (github.event_name == 'pull_request_target') && (
         contains(github.event.pull_request.labels.*.name, 'needs-integration-tests') ||
         (github.event.action == 'labeled' && github.event.label.name == 'needs-integration-tests')
       )


### PR DESCRIPTION
## Summary
- run the pre-merge integration workflow only for pull_request_target events to avoid duplicate runs
- always trigger the dev redeploy step after integration tests finish so the environment is reset even on failure

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7fbb75b483209cd4abd0214b39f0)