### PR TITLE
Fix integration workflow gating for dev redeploy

### DIFF
--- a/.github/workflows/pre-merge-integration.yml
+++ b/.github/workflows/pre-merge-integration.yml
@@ -18,8 +18,10 @@ jobs:
   deploy:
     if: >-
       (
-        github.event_name == 'pull_request_target' ||
         (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        ) || (
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         )
@@ -37,8 +39,10 @@ jobs:
   integration-tests:
     if: >-
       (
-        github.event_name == 'pull_request_target' ||
         (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        ) || (
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         )
@@ -79,9 +83,11 @@ jobs:
 
   redeploy-dev:
     if: >-
-      (
-        github.event_name == 'pull_request_target' ||
+      always() && (
         (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        ) || (
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         )


### PR DESCRIPTION
## Summary
- prevent the pre-merge integration workflow from triggering twice on same-repository pull requests by refining event filters
- allow the dev redeploy job to execute even when integration tests fail so the environment is reset consistently

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'markdown2')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f92a190e08320a0ce33fa033359ae)