### PR TITLE
feat: Surface available APIs on the landing page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -27,8 +27,15 @@
   background: linear-gradient(135deg, var(--primary), #27408b);
   color: #fff;
   padding: 4rem 0;
-  text-align: center;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.landing__hero-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+  text-align: center;
 }
 
 .landing__hero-title {
@@ -37,7 +44,7 @@
 }
 
 .landing__hero-subtitle {
-  margin: 0 0 1.5rem;
+  margin: 0;
   font-size: 1.2rem;
 }
 
@@ -49,13 +56,16 @@
   border-radius: 999px;
   text-decoration: none;
   font-weight: 600;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .landing__hero-cta:hover,
 .landing__hero-cta:focus {
   transform: translateY(-2px);
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+  background: #ffb65c;
 }
 
 .landing__main {
@@ -72,6 +82,96 @@
 
 .landing__section-body {
   margin: 0;
+}
+
+.landing__section--apis {
+  overflow-x: auto;
+}
+
+.landing__api-table-wrapper {
+  margin-top: 1.25rem;
+}
+
+.landing__api-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(17, 27, 46, 0.08);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.landing__api-table thead {
+  background: #e8edfb;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.landing__api-table th,
+.landing__api-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+}
+
+.landing__api-table tbody tr:nth-child(odd) {
+  background: #f8faff;
+}
+
+.landing__api-table tbody tr:nth-child(even) {
+  background: #fff;
+}
+
+.landing__api-table td[data-label]::before {
+  content: attr(data-label) ': ';
+  font-weight: 600;
+  display: none;
+  margin-right: 0.25rem;
+}
+
+.landing__api-loading,
+.landing__api-error {
+  margin: 1rem 0 0;
+}
+
+@media (max-width: 600px) {
+  .landing__api-table thead {
+    display: none;
+  }
+
+  .landing__api-table,
+  .landing__api-table tbody,
+  .landing__api-table tr,
+  .landing__api-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .landing__api-table tr {
+    border-bottom: 1px solid #e4e9f7;
+    padding: 0.75rem 0;
+  }
+
+  .landing__api-table td {
+    padding: 0.35rem 0;
+  }
+
+  .landing__api-table td[data-label]::before {
+    display: inline;
+  }
+}
+
+@media (min-width: 640px) {
+  .landing__hero-inner {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+  }
+
+  .landing__hero-copy {
+    max-width: 32rem;
+  }
 }
 
 .landing__feature-list {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,9 +8,12 @@
   </head>
   <body class="landing">
     <header class="landing__hero">
-      <div class="landing__container">
-        <h1 class="landing__hero-title">Welcome to Conflagent</h1>
-        <p class="landing__hero-subtitle">Your lightweight gateway for managing Confluence hierarchies.</p>
+      <div class="landing__container landing__hero-inner">
+        <div class="landing__hero-copy">
+          <h1 class="landing__hero-title">Welcome to Conflagent</h1>
+          <p class="landing__hero-subtitle">Your lightweight gateway for managing Confluence hierarchies.</p>
+        </div>
+        <button id="api-toggle" class="landing__hero-cta" type="button">Show available APIs</button>
       </div>
     </header>
     <main class="landing__main">
@@ -18,8 +21,9 @@
         <section class="landing__section">
           <h2 class="landing__section-title">Getting Started</h2>
           <p class="landing__section-body">
-            Use the REST endpoints under <code>/endpoint/&lt;endpoint_name&gt;</code> to explore and manage
-            your Confluence pages. Authenticate requests with a bearer token configured for your deployment.
+            Each configured endpoint exposes the same REST APIs under <code>/endpoint/&lt;endpoint_name&gt;</code>
+            for exploring and managing your Confluence spaces. Authenticate requests with a bearer token
+            associated with your deployment.
           </p>
         </section>
         <section class="landing__section">
@@ -29,6 +33,11 @@
             <li class="landing__feature-item">Create, update, and delete Confluence content programmatically.</li>
             <li class="landing__feature-item">Automatically handles markdown conversion and version conflicts.</li>
           </ul>
+        </section>
+        <section id="api-section" class="landing__section landing__section--apis" hidden>
+          <h2 class="landing__section-title">Available APIs</h2>
+          <p class="landing__section-body">The following operations are retrieved from the live OpenAPI definition.</p>
+          <div id="api-table-container" class="landing__api-table-wrapper" aria-live="polite"></div>
         </section>
       </div>
     </main>
@@ -63,5 +72,87 @@
         {% endif %}
       </div>
     </footer>
+    <script>
+      (function () {
+        const toggleButton = document.getElementById('api-toggle');
+        const apiSection = document.getElementById('api-section');
+        const tableContainer = document.getElementById('api-table-container');
+        let hasLoaded = false;
+
+        function createTable(paths) {
+          const table = document.createElement('table');
+          table.className = 'landing__api-table';
+
+          const thead = document.createElement('thead');
+          thead.innerHTML = '<tr><th scope="col">Method</th><th scope="col">Path</th><th scope="col">Description</th></tr>';
+          table.appendChild(thead);
+
+          const tbody = document.createElement('tbody');
+
+          Object.entries(paths).forEach(([path, operations]) => {
+            Object.entries(operations).forEach(([method, operation]) => {
+              if (method.startsWith('x-')) {
+                return;
+              }
+
+              const row = document.createElement('tr');
+              const description = operation.summary || operation.description || '';
+
+              row.innerHTML = `
+                <td data-label="Method">${method.toUpperCase()}</td>
+                <td data-label="Path">${path}</td>
+                <td data-label="Description">${description}</td>
+              `;
+              tbody.appendChild(row);
+            });
+          });
+
+          if (!tbody.children.length) {
+            const emptyRow = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.setAttribute('colspan', '3');
+            cell.textContent = 'No operations were found in the OpenAPI document.';
+            emptyRow.appendChild(cell);
+            tbody.appendChild(emptyRow);
+          }
+
+          table.appendChild(tbody);
+          return table;
+        }
+
+        async function fetchApis() {
+          tableContainer.innerHTML = '<p class="landing__api-loading">Loading available APIs…</p>';
+
+          try {
+            const response = await fetch('/openapi.json', { cache: 'no-store' });
+            if (!response.ok) {
+              throw new Error('Unable to load OpenAPI definition');
+            }
+
+            const spec = await response.json();
+            const table = createTable(spec.paths || {});
+            tableContainer.innerHTML = '';
+            tableContainer.appendChild(table);
+          } catch (error) {
+            tableContainer.innerHTML = '<p class="landing__api-error">Failed to load APIs. Please try again later.</p>';
+          }
+        }
+
+        toggleButton.addEventListener('click', () => {
+          const isHidden = apiSection.hasAttribute('hidden');
+          if (isHidden) {
+            apiSection.removeAttribute('hidden');
+            toggleButton.textContent = 'Hide available APIs';
+            if (!hasLoaded) {
+              fetchApis();
+              hasLoaded = true;
+            }
+          } else {
+            apiSection.setAttribute('hidden', '');
+            toggleButton.textContent = 'Show available APIs';
+          }
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a hero button that reveals the available APIs using the live `/openapi.json` document
- render the operations in a responsive table without loading them until requested and exclude security metadata
- refresh landing copy and styling to highlight that every configured endpoint exposes the same API set

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913552ab1348320bdb67244dbce2db6)