### PR TITLE
fix: drop auth from health and openapi endpoints

### DIFF
--- a/conflagent.py
+++ b/conflagent.py
@@ -784,7 +784,6 @@ def api_rename_page(endpoint_name: str):
     summary="Get OpenAPI schema",
     description="Returns this OpenAPI schema document.",
     operationId="getOpenAPISchema",
-    security=BEARER_SECURITY_REQUIREMENT,
     responses={
         "200": {
             "description": "OpenAPI JSON returned",
@@ -797,7 +796,6 @@ def api_rename_page(endpoint_name: str):
     },
 )
 def openapi_schema(endpoint_name: str):
-    check_auth()
     spec = generate_openapi_spec(endpoint_name, request.host_url, app)
     return jsonify(spec)
 
@@ -810,7 +808,6 @@ def openapi_schema(endpoint_name: str):
     summary="Health check",
     description="Check whether API server is live. No authentication required.",
     operationId="healthCheck",
-    security=BEARER_SECURITY_REQUIREMENT,
     responses={
         "200": {
             "description": "Server is running",
@@ -834,7 +831,6 @@ def openapi_schema(endpoint_name: str):
     },
 )
 def api_health(endpoint_name: str):
-    check_auth()
     return _success("Service healthy.", data={"status": "ok"})
 
 

--- a/tests/integration/test_dev_integration.py
+++ b/tests/integration/test_dev_integration.py
@@ -349,9 +349,10 @@ def hierarchy_titles(dev_config: Dict[str, str]) -> HierarchyTitles:
 def test_endpoint_health_reports_ok(dev_config: Dict[str, str]):
     response = requests.get(
         _full_url(dev_config, "/health"),
-        headers=_auth_headers(dev_config["token"]),
         timeout=10,
     )
+    # Endpoint-level health should be accessible without authentication so that
+    # tooling can probe readiness without managing tokens.
     assert response.status_code == 200
     content_type = response.headers.get("Content-Type", "")
     assert "application/json" in content_type
@@ -413,9 +414,9 @@ def test_missing_page_returns_404(dev_config: Dict[str, str]):
 def test_endpoint_openapi_schema_includes_endpoint_server(dev_config: Dict[str, str]):
     response = requests.get(
         _full_url(dev_config, "/openapi.json"),
-        headers=_auth_headers(dev_config["token"]),
         timeout=10,
     )
+    # The endpoint-specific OpenAPI document should also be publicly readable.
     assert response.status_code == 200
     payload = response.json()
     assert "servers" in payload

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -387,7 +387,7 @@ def test_rename_page_missing_source(mock_load_config, mock_client_cls, client):
 
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_health(mock_load_config, client):
-    response = client.get(f"/endpoint/{endpoint}/health", headers=headers)
+    response = client.get(f"/endpoint/{endpoint}/health")
     assert response.status_code == 200
     payload = response.get_json()
     assert payload["success"] is True
@@ -429,7 +429,7 @@ def test_timestamp_field_is_iso8601(mock_load_config, mock_client_cls, client):
 
 @patch("conflagent_core.config.load_config", return_value=mock_config)
 def test_openapi_schema(mock_load_config, client):
-    response = client.get(f"/endpoint/{endpoint}/openapi.json", headers=headers)
+    response = client.get(f"/endpoint/{endpoint}/openapi.json")
     assert response.status_code == 200
     data = response.get_json()
     assert "paths" in data


### PR DESCRIPTION
## Summary
- remove bearer auth requirements from the endpoint-specific OpenAPI and health routes
- update unit and integration tests to ensure the routes work without authentication

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69137097f8cc8320ae54cb8f3addd199)